### PR TITLE
fix: send proper user agent headers

### DIFF
--- a/lib/config_cat/api.ex
+++ b/lib/config_cat/api.ex
@@ -2,13 +2,6 @@ defmodule ConfigCat.API do
   use HTTPoison.Base
 
   def process_request_headers(headers) do
-    version = Application.spec(:config_cat, :vsn) |> to_string()
-    user_agent = "ConfigCat-Elixir/m-#{version}"
-
-    [
-      {"User-Agent", user_agent},
-      {"X-ConfigCat-UserAgent", user_agent},
-      {"Content-Type", "application/json"} | headers
-    ]
+    [{"Content-Type", "application/json"} | headers]
   end
 end

--- a/lib/config_cat/api.ex
+++ b/lib/config_cat/api.ex
@@ -2,9 +2,12 @@ defmodule ConfigCat.API do
   use HTTPoison.Base
 
   def process_request_headers(headers) do
+    version = Application.spec(:config_cat, :vsn) |> to_string()
+    user_agent = "ConfigCat-Elixir/m-#{version}"
+
     [
-      {"User-Agent", "ConfigCat-Elixir/m-0.0.1"},
-      {"X-ConfigCat-UserAgent", "ConfigCat-Elixir/m-0.0.1"},
+      {"User-Agent", user_agent},
+      {"X-ConfigCat-UserAgent", user_agent},
       {"Content-Type", "application/json"} | headers
     ]
   end

--- a/lib/config_cat/fetch_policy.ex
+++ b/lib/config_cat/fetch_policy.ex
@@ -22,6 +22,10 @@ defmodule ConfigCat.FetchPolicy do
     }
   end
 
+  def mode(%__MODULE__{type: :auto}), do: "a"
+  def mode(%__MODULE__{type: :lazy}), do: "l"
+  def mode(%__MODULE__{type: :manual}), do: "m"
+
   def needs_fetch?(%__MODULE__{type: :lazy}, nil), do: true
 
   def needs_fetch?(

--- a/test/fetch_policy_test.exs
+++ b/test/fetch_policy_test.exs
@@ -98,4 +98,21 @@ defmodule ConfigCat.FetchPolicyTest do
       refute_receive :refresh
     end
   end
+
+  describe "fetch mode" do
+    test "is m for manual" do
+      mode = FetchPolicy.manual() |> FetchPolicy.mode()
+      assert mode == "m"
+    end
+
+    test "is a for auto" do
+      mode = FetchPolicy.auto() |> FetchPolicy.mode()
+      assert mode == "a"
+    end
+
+    test "is l for lazy" do
+      mode = FetchPolicy.lazy(cache_expiry_seconds: 60) |> FetchPolicy.mode()
+      assert mode == "l"
+    end
+  end
 end


### PR DESCRIPTION
Fixes #16 
Fixes #17 

Send the proper user agent headers with each request to the ConfigCat server.  The header should include the proper mode ("a" = auto, "l" = lazy, "m" = manual) as well as the version as specified in `mix.exs`.

This moves the user agent headers into the `ConfigCat` module where we have access to the fetch policy, which allows use to determine the mode.

I had to change the ETag-related tests to allow for the additional headers to be present and also tested that we're sending the right user agent headers for each mode.