### PR TITLE
refactor: Move JSON decoding to API

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -120,10 +120,9 @@ defmodule ConfigCat do
     end
   end
 
-  defp handle_response(%Response{status_code: code, body: body, headers: headers}, state)
+  defp handle_response(%Response{status_code: code, body: config, headers: headers}, state)
        when code >= 200 and code < 300 do
-    with {:ok, config} = Jason.decode(body),
-         etag <- extract_etag(headers) do
+    with etag <- extract_etag(headers) do
       {:ok, %{state | config: config, etag: etag, last_update: now()}}
     end
   end

--- a/lib/config_cat/api.ex
+++ b/lib/config_cat/api.ex
@@ -2,6 +2,16 @@ defmodule ConfigCat.API do
   use HTTPoison.Base
 
   def process_request_headers(headers) do
-    [{"Content-Type", "application/json"} | headers]
+    [{"Accept", "application/json"} | headers]
+  end
+
+  def process_response_body(""), do: ""
+
+  def process_response_body(body) do
+    with {:ok, parsed} <- Jason.decode(body) do
+      parsed
+    else
+      _ -> body
+    end
   end
 end

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -37,7 +37,7 @@ defmodule ConfigCatTest do
 
       APIMock
       |> stub(:get, fn ^url, _headers ->
-        {:ok, %Response{status_code: 200, body: Jason.encode!(config)}}
+        {:ok, %Response{status_code: 200, body: config}}
       end)
 
       :ok = ConfigCat.force_refresh(client)
@@ -47,7 +47,7 @@ defmodule ConfigCatTest do
     test "sends proper user agent header" do
       {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.manual())
 
-      response = %Response{status_code: 200, body: Jason.encode!(%{})}
+      response = %Response{status_code: 200, body: %{}}
 
       APIMock
       |> stub(:get, fn _url, headers ->
@@ -65,7 +65,7 @@ defmodule ConfigCatTest do
 
       initial_response = %Response{
         status_code: 200,
-        body: Jason.encode!(%{}),
+        body: %{},
         headers: [{"ETag", etag}]
       }
 
@@ -145,7 +145,7 @@ defmodule ConfigCatTest do
 
       APIMock
       |> expect(:get, fn ^url, _headers ->
-        {:ok, %Response{status_code: 200, body: Jason.encode!(%{})}}
+        {:ok, %Response{status_code: 200, body: %{}}}
       end)
 
       :ok = ConfigCat.force_refresh(client)
@@ -160,7 +160,7 @@ defmodule ConfigCatTest do
     } do
       APIMock
       |> stub(:get, fn _url, _headers ->
-        {:ok, %Response{status_code: 200, body: Jason.encode!(config)}}
+        {:ok, %Response{status_code: 200, body: config}}
       end)
 
       {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.auto())
@@ -171,7 +171,7 @@ defmodule ConfigCatTest do
     test "sends proper user agent header" do
       {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.auto())
 
-      response = %Response{status_code: 200, body: Jason.encode!(%{})}
+      response = %Response{status_code: 200, body: %{}}
 
       APIMock
       |> stub(:get, fn _url, headers ->
@@ -214,7 +214,7 @@ defmodule ConfigCatTest do
 
       APIMock
       |> stub(:get, fn _url, _headers ->
-        {:ok, %Response{status_code: 200, body: Jason.encode!(config)}}
+        {:ok, %Response{status_code: 200, body: config}}
       end)
 
       assert ConfigCat.get_value(feature, "default", client: client) == value
@@ -227,7 +227,7 @@ defmodule ConfigCatTest do
           fetch_policy: FetchPolicy.lazy(cache_expiry_seconds: 300)
         )
 
-      response = %Response{status_code: 200, body: Jason.encode!(%{})}
+      response = %Response{status_code: 200, body: %{}}
 
       APIMock
       |> stub(:get, fn _url, headers ->
@@ -252,7 +252,7 @@ defmodule ConfigCatTest do
 
       APIMock
       |> expect(:get, 1, fn _url, _headers ->
-        {:ok, %Response{status_code: 200, body: Jason.encode!(config)}}
+        {:ok, %Response{status_code: 200, body: config}}
       end)
 
       ConfigCat.get_value(feature, "default", client: client)
@@ -272,7 +272,7 @@ defmodule ConfigCatTest do
 
       APIMock
       |> expect(:get, 2, fn _url, _headers ->
-        {:ok, %Response{status_code: 200, body: Jason.encode!(config)}}
+        {:ok, %Response{status_code: 200, body: config}}
       end)
 
       ConfigCat.get_value(feature, "default", client: client)


### PR DESCRIPTION
Moves the `Jason.decode` call into the `API` module using HTTPoison's `process_response_body`.

This simplifies the application a bit by not having to decode, and also simplifies the stubbed API responses in `config_cat_test.exs` by not having to encode.

There's a couple of tests that get back an HTML 404 response (from nginx), even after specifying an `Accept` header, so I added protection against that and return the body unmodified in that case.

I also realized that there was no need to specify a `Content-Type` header because we only make `GET` requests and those don't have content.