### PR TITLE
Stop down-casing property names

### DIFF
--- a/lib/config_cat/rollout.ex
+++ b/lib/config_cat/rollout.ex
@@ -121,7 +121,7 @@ defmodule ConfigCat.Rollout do
   defp increment_bucket(bucket, rule), do: bucket + Map.get(rule, @percentage, 0)
 
   defp hash_user(user, key) do
-    user_key = User.get_attribute(user, "identifier")
+    user_key = User.get_attribute(user, "Identifier")
     hash_candidate = "#{key}#{user_key}"
 
     {hash_value, _} =

--- a/lib/config_cat/user.ex
+++ b/lib/config_cat/user.ex
@@ -1,6 +1,6 @@
 defmodule ConfigCat.User do
   @enforce_keys :identifier
-  defstruct [:identifier, country: "", email: "", custom: %{}]
+  defstruct [:identifier, country: nil, email: nil, custom: nil]
 
   def new(identifier, other_props \\ []) do
     %__MODULE__{identifier: identifier}

--- a/lib/config_cat/user.ex
+++ b/lib/config_cat/user.ex
@@ -8,7 +8,7 @@ defmodule ConfigCat.User do
   end
 
   def get_attribute(user, attribute) do
-    do_get_attribute(user, normalize(attribute))
+    do_get_attribute(user, attribute)
   end
 
   defp do_get_attribute(user, "Identifier"), do: user.identifier
@@ -20,15 +20,10 @@ defmodule ConfigCat.User do
 
   defp custom_attribute(custom, attribute) do
     case Enum.find(custom, fn {key, _value} ->
-           normalize(key) == attribute
+           key == attribute
          end) do
       {_key, value} -> value
       _ -> nil
     end
-  end
-
-  defp normalize(attribute) do
-    attribute
-    |> to_string()
   end
 end

--- a/lib/config_cat/user.ex
+++ b/lib/config_cat/user.ex
@@ -8,7 +8,7 @@ defmodule ConfigCat.User do
   end
 
   def get_attribute(user, attribute) do
-    do_get_attribute(user, attribute)
+    do_get_attribute(user, normalize(attribute))
   end
 
   defp do_get_attribute(user, "Identifier"), do: user.identifier
@@ -20,10 +20,15 @@ defmodule ConfigCat.User do
 
   defp custom_attribute(custom, attribute) do
     case Enum.find(custom, fn {key, _value} ->
-           key == attribute
+           normalize(key) == attribute
          end) do
       {_key, value} -> value
       _ -> nil
     end
+  end
+
+  defp normalize(attribute) do
+    attribute
+    |> to_string()
   end
 end

--- a/lib/config_cat/user.ex
+++ b/lib/config_cat/user.ex
@@ -11,26 +11,24 @@ defmodule ConfigCat.User do
     do_get_attribute(user, normalize(attribute))
   end
 
-  defp do_get_attribute(user, "identifier"), do: user.identifier
-  defp do_get_attribute(user, "country"), do: user.country
-  defp do_get_attribute(user, "email"), do: user.email
+  defp do_get_attribute(user, "Identifier"), do: user.identifier
+  defp do_get_attribute(user, "Country"), do: user.country
+  defp do_get_attribute(user, "Email"), do: user.email
   defp do_get_attribute(user, attribute), do: custom_attribute(user.custom, attribute)
 
-  defp custom_attribute(nil, _attribute), do: ""
-  defp custom_attribute("", _attribute), do: ""
+  defp custom_attribute(nil, _attribute), do: nil
 
   defp custom_attribute(custom, attribute) do
     case Enum.find(custom, fn {key, _value} ->
            normalize(key) == attribute
          end) do
       {_key, value} -> value
-      _ -> ""
+      _ -> nil
     end
   end
 
   defp normalize(attribute) do
     attribute
     |> to_string()
-    |> String.downcase()
   end
 end

--- a/test/user_test.exs
+++ b/test/user_test.exs
@@ -41,6 +41,7 @@ defmodule ConfigCat.UserTest do
           email: "EMAIL",
           country: "COUNTRY",
           custom: %{
+            :atom_property => "ATOM_VALUE",
             "string_property" => "STRING_VALUE",
             "UpperStringProperty" => "UPPER_STRING_VALUE"
           }
@@ -62,6 +63,11 @@ defmodule ConfigCat.UserTest do
     test "looks up country", %{user: user} do
       value = User.get_attribute(user, "Country")
       assert value == user.country
+    end
+
+    test "looks up a custom property with an atom key", %{user: user} do
+      value = User.get_attribute(user, "atom_property")
+      assert value == user.custom[:atom_property]
     end
 
     test "looks up a custom property with a string key", %{user: user} do

--- a/test/user_test.exs
+++ b/test/user_test.exs
@@ -41,7 +41,6 @@ defmodule ConfigCat.UserTest do
           email: "EMAIL",
           country: "COUNTRY",
           custom: %{
-            :atom_property => "ATOM_VALUE",
             "string_property" => "STRING_VALUE",
             "UpperStringProperty" => "UPPER_STRING_VALUE"
           }
@@ -63,11 +62,6 @@ defmodule ConfigCat.UserTest do
     test "looks up country", %{user: user} do
       value = User.get_attribute(user, "Country")
       assert value == user.country
-    end
-
-    test "looks up a custom property with an atom key", %{user: user} do
-      value = User.get_attribute(user, "atom_property")
-      assert value == user.custom[:atom_property]
     end
 
     test "looks up a custom property with a string key", %{user: user} do

--- a/test/user_test.exs
+++ b/test/user_test.exs
@@ -66,18 +66,13 @@ defmodule ConfigCat.UserTest do
     end
 
     test "looks up a custom property with an atom key", %{user: user} do
-      value = User.get_attribute(user, "ATOM_PROPERTY")
+      value = User.get_attribute(user, "atom_property")
       assert value == user.custom[:atom_property]
     end
 
     test "looks up a custom property with a string key", %{user: user} do
-      value = User.get_attribute(user, "STRING_PROPERTY")
+      value = User.get_attribute(user, "string_property")
       assert value == user.custom["string_property"]
-    end
-
-    test "looks up a custom property with a string key with uppercase letters", %{user: user} do
-      value = User.get_attribute(user, "upperstringproperty")
-      assert value == user.custom["UpperStringProperty"]
     end
 
     test "returns nil for null attributes" do

--- a/test/user_test.exs
+++ b/test/user_test.exs
@@ -8,7 +8,7 @@ defmodule ConfigCat.UserTest do
       identifier = "IDENTIFIER"
       user = User.new(identifier)
 
-      assert %User{identifier: ^identifier, email: "", country: "", custom: %{}} = user
+      assert %User{identifier: ^identifier, email: nil, country: nil, custom: nil} = user
     end
 
     test "creates a user with additional properties" do
@@ -17,7 +17,7 @@ defmodule ConfigCat.UserTest do
       country = "COUNTRY"
       user = User.new(identifier, email: email, country: country)
 
-      assert %User{identifier: ^identifier, email: ^email, country: ^country, custom: %{}} = user
+      assert %User{identifier: ^identifier, email: ^email, country: ^country, custom: nil} = user
     end
 
     test "creates a user with custom properties" do
@@ -27,8 +27,8 @@ defmodule ConfigCat.UserTest do
 
       assert %User{
                identifier: ^identifier,
-               email: "",
-               country: "",
+               email: nil,
+               country: nil,
                custom: %{custom_property: ^custom_property}
              } = user
     end
@@ -83,9 +83,9 @@ defmodule ConfigCat.UserTest do
     test "returns nil for null attributes" do
       user = User.new("IDENTIFIER")
 
-      assert User.get_attribute(user, "Email") == ""
-      assert User.get_attribute(user, "Country") == ""
-      assert User.get_attribute(user, "AnyCustom") == ""
+      assert User.get_attribute(user, "Email") == nil
+      assert User.get_attribute(user, "Country") == nil
+      assert User.get_attribute(user, "AnyCustom") == nil
     end
   end
 end


### PR DESCRIPTION
* It resolves issue #12 
* Following ruby SDK defaults for struct initialization (https://github.com/configcat/ruby-sdk/blob/master/lib/configcat/user.rb#L10)
* Stop normalizing user attributes
* Maybe atom keys isn't a use case and we can remove the normalize method completely (?) (https://github.com/configcat/ruby-sdk/blob/master/spec/configcat/user_spec.rb)
