### PR TITLE
Features/http proxy

### DIFF
--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -266,13 +266,18 @@ defmodule ConfigCatTest do
           fetch_policy: FetchPolicy.lazy(cache_expiry_seconds: 300)
         )
 
+      call_times = 10
+
       APIMock
-      |> expect(:get, 1, fn _url, _headers ->
+      |> expect(:get, 1, fn _url, _headers, _options ->
         {:ok, %Response{status_code: 200, body: config}}
       end)
 
-      ConfigCat.get_value(feature, "default", client: client)
-      assert ConfigCat.get_value(feature, "default", client: client) == value
+      result = Enum.reduce 1..call_times, 0, fn _n, _a ->
+        ConfigCat.get_value(feature, "default", client: client)
+      end
+
+      assert result == value
     end
 
     test "refetches configuration if cache has expired", %{
@@ -286,13 +291,18 @@ defmodule ConfigCatTest do
           fetch_policy: FetchPolicy.lazy(cache_expiry_seconds: 0)
         )
 
+      call_times = 2
+
       APIMock
-      |> expect(:get, 2, fn _url, _headers ->
+      |> expect(:get, call_times, fn _url, _headers, _options ->
         {:ok, %Response{status_code: 200, body: config}}
       end)
 
-      ConfigCat.get_value(feature, "default", client: client)
-      assert ConfigCat.get_value(feature, "default", client: client) == value
+      result = Enum.reduce 1..call_times, 0, fn _n, _a ->
+        ConfigCat.get_value(feature, "default", client: client)
+      end
+
+      assert result == value
     end
   end
 

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -263,7 +263,7 @@ defmodule ConfigCatTest do
           fetch_policy: FetchPolicy.lazy(cache_expiry_seconds: 300)
         )
 
-      call_times = 10
+      call_times = 2
 
       APIMock
       |> expect(:get, 1, fn _url, _headers, _options ->

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -36,8 +36,7 @@ defmodule ConfigCatTest do
       {:ok, client} = start_config_cat(sdk_key, fetch_policy: FetchPolicy.manual())
 
       APIMock
-      |> stub(:get, fn ^url, _headers, options ->
-        assert options == []
+      |> stub(:get, fn ^url, _headers, [] ->
         {:ok, %Response{status_code: 200, body: config}}
       end)
 
@@ -158,9 +157,7 @@ defmodule ConfigCatTest do
       response = %Response{status_code: 200, body: %{}}
 
       APIMock
-      |> stub(:get, fn _url, _headers, options ->
-        assert options == [proxy: "https://myproxy.com"]
-
+      |> stub(:get, fn _url, _headers, [proxy: "https://myproxy.com"] ->
         {:ok, response}
       end)
 


### PR DESCRIPTION
Addresses #8 

```elixir
ConfigCat.start_link(sdk_key, http_proxy: "https://myproxy"))
```

With user authorization:

```elixir
ConfigCat.start_link(sdk_key, http_proxy: "https://user:pass@myproxy"))
```