### PR TITLE
fix: eliminate race conditions in tests

### DIFF
--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -125,7 +125,7 @@ defmodule ConfigCatTest do
 
     @tag capture_log: true
     test "handles error response from ConfigCat" do
-      {:ok, client} = start_config_cat("SDK_KEY")
+      {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.manual())
 
       error = %HTTPoison.Error{reason: "failed"}
 
@@ -182,16 +182,14 @@ defmodule ConfigCatTest do
     end
 
     test "sends proper user agent header" do
-      {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.auto())
-
-      response = %Response{status_code: 200, body: %{}}
-
       APIMock
       |> stub(:get, fn _url, headers, _options ->
         assert_user_agent_matches(headers, ~r"^ConfigCat-Elixir/a-")
 
-        {:ok, response}
+        {:ok, %Response{status_code: 200, body: %{}}}
       end)
+
+      {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.auto())
 
       assert :ok = ConfigCat.force_refresh(client)
     end


### PR DESCRIPTION
When @igorescobar tried to run Erlang 22 in CI, a couple of tests failed consistently.

These tests were both starting ConfigCat with an auto refresh policy. The auto refresh ended up happening before we could define the `stub` response to the `GET` request it was making, resulting in the failure.

One of the tests didn't need an auto fetch policy, so I switched it to manual.  For the other, I moved the `stub` definition prior to the `start_config_cat` call as it is in the other auto policy tests.

I didn't restore the use of Erlang 22 in the CI configuration; we can do that once we decide which versions of Elixir we want to support.