### PR TITLE
ConfigCat.get_variation_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ erl_crash.dump
 *.beam
 /config/*.secret.exs
 .elixir_ls/
+.vscode/

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -335,6 +335,13 @@ defmodule ConfigCatTest do
     end
   end
 
+  describe "get_variation_id" do
+    test "" do
+      {:ok, client} = start_config_cat("SDK_KEY", fetch_policy: FetchPolicy.manual())
+      assert ConfigCat.get_variation_id("any_feature", "default", client: client) == "default"
+    end
+  end
+
   defp start_config_cat(sdk_key, options \\ []) do
     name = UUID.uuid4() |> String.to_atom()
     ConfigCat.start_link(sdk_key, Keyword.merge([api: APIMock, name: name], options))

--- a/test/fixtures/testmatrix_variationId.csv
+++ b/test/fixtures/testmatrix_variationId.csv
@@ -1,0 +1,8 @@
+Identifier;Email;Country;Custom1;boolean;decimal;text;whole
+##null##;;;;a0e56eda;63612d39;3f05be89;cf2e9162;
+a@configcat.com;a@configcat.com;Hungary;admin;67787ae4;8f9559cf;9bdc6a1f;ab30533b;
+b@configcat.com;b@configcat.com;Hungary;admin;67787ae4;8f9559cf;9bdc6a1f;ab30533b;
+a@test.com;a@test.com;Hungary;admin;67787ae4;d66c5781;65310deb;ec14f6a9;
+b@test.com;b@test.com;Hungary;admin;a0e56eda;d66c5781;65310deb;ec14f6a9;
+cliffordj@aol.com;cliffordj@aol.com;Hungary;admin;67787ae4;8155ad7b;cf19e913;ec14f6a9;
+bryanw@verizon.net;bryanw@verizon.net;Hungary;;a0e56eda;d0dbc27f;30ba32b9;61a5a033;

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -14,6 +14,15 @@ defmodule ConfigCat.IntegrationTest do
              "This text came from ConfigCat"
   end
 
+  test "fetches variation_id" do
+    {:ok, client} = start_config_cat(@sdk_key)
+
+    :ok = ConfigCat.force_refresh(client)
+
+    assert ConfigCat.get_variation_id("keySampleText", "default", client: client) ==
+             "eda16475"
+  end
+
   test "maintains previous configuration when config has not changed between refreshes" do
     {:ok, client} = start_config_cat(@sdk_key)
 


### PR DESCRIPTION
Addressing  #20 
I believe the major change is that now the `evaluate` method returns two values `{ value, variation }` instead of just one value. Following the same standard as the other SDKs.