### PR TITLE
feat: allow caller to provide a custom cache implementation

### DIFF
--- a/lib/config_cat/config_cache.ex
+++ b/lib/config_cat/config_cache.ex
@@ -1,0 +1,6 @@
+defmodule ConfigCat.ConfigCache do
+  @type cache_key :: String.t()
+
+  @callback get(cache_key) :: {:ok, map()} | {:error, :not_found}
+  @callback set(cache_key, map()) :: :ok
+end

--- a/lib/config_cat/in_memory_cache.ex
+++ b/lib/config_cat/in_memory_cache.ex
@@ -1,0 +1,50 @@
+defmodule ConfigCat.InMemoryCache do
+  use GenServer
+
+  alias ConfigCat.ConfigCache
+
+  @behaviour ConfigCache
+
+  def start_link(options) do
+    name =
+      options
+      |> Keyword.fetch!(:cache_key)
+      |> name_from_cache_key()
+
+    GenServer.start_link(__MODULE__, :empty, name: name)
+  end
+
+  @impl ConfigCache
+  def get(cache_key) do
+    GenServer.call(name_from_cache_key(cache_key), :get)
+  end
+
+  @impl ConfigCache
+  def set(cache_key, value) do
+    GenServer.call(name_from_cache_key(cache_key), {:set, value})
+  end
+
+  defp name_from_cache_key(cache_key) do
+    String.to_atom(cache_key)
+  end
+
+  @impl GenServer
+  def init(state) do
+    {:ok, state}
+  end
+
+  @impl GenServer
+  def handle_call(:get, _from, :empty = state) do
+    {:reply, {:error, :not_found}, state}
+  end
+
+  @impl GenServer
+  def handle_call(:get, _from, state) do
+    {:reply, {:ok, state}, state}
+  end
+
+  @impl GenServer
+  def handle_call({:set, value}, _from, _state) do
+    {:reply, :ok, value}
+  end
+end

--- a/test/config_cat/in_memory_cache_test.exs
+++ b/test/config_cat/in_memory_cache_test.exs
@@ -1,0 +1,25 @@
+defmodule ConfigCat.InMemoryCacheTest do
+  use ExUnit.Case, async: true
+
+  alias ConfigCat.InMemoryCache, as: Cache
+
+  @cache_key "CACHE_KEY"
+
+  setup do
+    {:ok, _pid} = Cache.start_link(cache_key: @cache_key)
+
+    :ok
+  end
+
+  test "cache is initially empty" do
+    assert Cache.get(@cache_key) == {:error, :not_found}
+  end
+
+  test "returns cached value" do
+    config = %{"some" => "config"}
+
+    :ok = Cache.set(@cache_key, config)
+
+    assert {:ok, ^config} = Cache.get(@cache_key)
+  end
+end


### PR DESCRIPTION
Closes #10
Part of #37 

We now allow the calling application to specify a `cache_api` to replace our default `InMemoryCache`.

The calling application is responsible for adding its cache to its own supervision tree.

If no cache_api is provided, we supply our own default `InMemoryCache`, adding it to our supervision tree.

To ensure that each ConfigCat instance has its own cache, we use the `cache_key` (after converting to an atom) as the GenServer name.  Each `InMemoryCache` instance stores the config as its state and we use the cache key to communicate with the correct GenServer.

Also:
- added more tests around `get_variant_id`
- remove the `nil` config check in `Rollout`; with this refactoring, we no longer call `Rollout` with a null config so we don't need to guard against it.