### PR TITLE
chore: remove fetcher_id from client options

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -46,7 +46,6 @@ defmodule ConfigCat do
     client_options =
       options
       |> Keyword.put(:cache_policy_id, policy_options[:name])
-      |> Keyword.put(:fetcher_id, fetcher_options[:name])
       |> client_options()
 
     children =


### PR DESCRIPTION
Client no longer uses the fetcher directly, so doesn't need its id. It was already filtering it out in `client_options`.