### PR TITLE
feat: allow on_change callback in auto-polling mode

### DIFF
--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -4,7 +4,7 @@ defmodule ConfigCat.CachePolicy.Auto do
   alias ConfigCat.CachePolicy
   alias ConfigCat.CachePolicy.Helpers
 
-  defstruct poll_interval_seconds: 60, mode: "a"
+  defstruct mode: "a", on_changed: nil, poll_interval_seconds: 60
 
   @behaviour CachePolicy
 
@@ -49,7 +49,7 @@ defmodule ConfigCat.CachePolicy.Auto do
 
   @impl GenServer
   def handle_call(:force_refresh, _from, state) do
-    case Helpers.refresh_config(state) do
+    case refresh(state) do
       :ok ->
         {:reply, :ok, state}
 
@@ -59,9 +59,21 @@ defmodule ConfigCat.CachePolicy.Auto do
   end
 
   defp polled_refresh(%{poll_interval_seconds: seconds} = state) do
-    Helpers.refresh_config(state)
+    refresh(state)
     Process.send_after(self(), :polled_refresh, seconds * 1000)
 
     {:noreply, state}
+  end
+
+  defp refresh(state) do
+    with original <- Helpers.cached_config(state),
+         :ok <- Helpers.refresh_config(state) do
+      unless Helpers.cached_config(state) == original do
+        callback = state[:on_changed] || fn -> :ok end
+        callback.()
+      end
+
+      :ok
+    end
   end
 end

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -27,6 +27,17 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       policy = CachePolicy.auto(poll_interval_seconds: -1)
       assert policy.poll_interval_seconds == 1
     end
+
+    test "does not have a change callback by default" do
+      policy = CachePolicy.auto()
+      assert policy.on_changed == nil
+    end
+
+    test "takes an optional change callback" do
+      callback = fn -> :ok end
+      policy = CachePolicy.auto(on_changed: callback)
+      assert policy.on_changed == callback
+    end
   end
 
   describe "getting the config" do
@@ -55,25 +66,84 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       {:ok, policy_id} = start_cache_policy(policy)
 
       expect_refresh(config)
-
-      delay_ms = policy.poll_interval_seconds * 1000 + 50
-      Process.sleep(delay_ms)
+      wait_for_poll(policy)
 
       assert {:ok, ^config} = Auto.get(policy_id)
+    end
+
+    test "calls the change callback after refreshing", %{config: config} do
+      test_pid = self()
+      interval = 1
+      old_config = %{"old" => "config"}
+
+      expect_refresh(old_config)
+
+      policy =
+        CachePolicy.auto(
+          on_changed: fn -> send(test_pid, :callback) end,
+          poll_interval_seconds: interval
+        )
+
+      {:ok, _} = start_cache_policy(policy)
+
+      assert_receive(:callback)
+
+      expect_refresh(config)
+      wait_for_poll(policy)
+
+      assert_receive(:callback)
+    end
+
+    test "doesn't call the change callback if the configuration hasn't changed", %{config: config} do
+      test_pid = self()
+      interval = 1
+
+      expect_refresh(config)
+
+      policy =
+        CachePolicy.auto(
+          on_changed: fn -> send(test_pid, :callback) end,
+          poll_interval_seconds: interval
+        )
+
+      {:ok, _} = start_cache_policy(policy)
+
+      assert_receive(:callback)
+
+      expect_unchanged()
+      wait_for_poll(policy)
+
+      refute_receive(:callback)
     end
   end
 
   describe "refreshing the config" do
     test "stores new config in the cache", %{config: config} do
       old_config = %{"old" => "config"}
-
       expect_refresh(old_config)
+
       {:ok, policy_id} = start_cache_policy(@policy)
       assert {:ok, ^old_config} = Auto.get(policy_id)
 
       expect_refresh(config)
       assert :ok = Auto.force_refresh(policy_id)
       assert {:ok, ^config} = Auto.get(policy_id)
+    end
+
+    test "calls the change callback", %{config: config} do
+      test_pid = self()
+      old_config = %{"old" => "config"}
+      expect_refresh(old_config)
+
+      policy = CachePolicy.auto(on_changed: fn -> send(test_pid, :callback) end)
+      {:ok, policy_id} = start_cache_policy(policy)
+
+      assert_receive(:callback)
+
+      expect_refresh(config)
+      :ok = Auto.force_refresh(policy_id)
+
+      assert_receive(:callback)
     end
 
     test "does not update config when server responds that the config hasn't changed", %{
@@ -94,5 +164,10 @@ defmodule ConfigCat.CachePolicy.AutoTest do
 
       assert_returns_error(fn -> Auto.force_refresh(policy_id) end)
     end
+  end
+
+  defp wait_for_poll(policy) do
+    (policy.poll_interval_seconds * 1000 + 50)
+    |> Process.sleep()
   end
 end

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -146,6 +146,16 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       assert_receive(:callback)
     end
 
+    @tag capture_log: true
+    test "handles errors in the change callback", %{config: config} do
+      expect_refresh(config)
+
+      policy = CachePolicy.auto(on_changed: fn -> raise RuntimeError, "callback failed" end)
+      {:ok, policy_id} = start_cache_policy(policy)
+
+      assert {:ok, ^config} = Auto.get(policy_id)
+    end
+
     test "does not update config when server responds that the config hasn't changed", %{
       config: config
     } do

--- a/test/config_cat/cache_policy/lazy_test.exs
+++ b/test/config_cat/cache_policy/lazy_test.exs
@@ -58,6 +58,7 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       expect_refresh(config)
 
       assert :ok = Lazy.force_refresh(policy_id)
+      assert {:ok, ^config} = Lazy.get(policy_id)
     end
 
     test "fetches new config even if cache is not expired", %{config: config} do

--- a/test/config_cat/cache_policy/manual_test.exs
+++ b/test/config_cat/cache_policy/manual_test.exs
@@ -19,12 +19,12 @@ defmodule ConfigCat.CachePolicy.ManualTest do
   end
 
   describe "getting the config" do
-    test "returns the config from the cache without refreshing", %{config: config} do
+    test "returns the config from the cache without refreshing" do
       {:ok, policy_id} = start_cache_policy(@policy)
 
       expect_not_refreshed()
 
-      assert {:ok, ^config} = Manual.get(policy_id)
+      assert {:error, :not_found} = Manual.get(policy_id)
     end
   end
 
@@ -35,6 +35,7 @@ defmodule ConfigCat.CachePolicy.ManualTest do
       expect_refresh(config)
 
       assert :ok = Manual.force_refresh(policy_id)
+      assert {:ok, ^config} = Manual.get(policy_id)
     end
 
     test "does not update config when server responds that the config hasn't changed" do

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -3,10 +3,9 @@ defmodule ConfigCat.CachePolicyCase do
 
   import Mox
 
-  alias ConfigCat.{CachePolicy, MockCache, MockFetcher}
+  alias ConfigCat.{CachePolicy, InMemoryCache, MockFetcher}
   alias HTTPoison.Response
 
-  @cache_key "CACHE_KEY"
   @fetcher_id :fetcher_id
 
   using do
@@ -18,53 +17,49 @@ defmodule ConfigCat.CachePolicyCase do
   setup do
     config = %{"some" => "config"}
 
-    MockCache
-    |> stub(:get, fn @cache_key -> {:ok, config} end)
-
     {:ok, config: config}
   end
 
   def start_cache_policy(policy) do
     policy_id = UUID.uuid4() |> String.to_atom()
 
+    {:ok, cache_key} = start_cache()
+
     {:ok, _pid} =
       CachePolicy.start_link(
-        cache: MockCache,
-        cache_key: @cache_key,
+        cache: InMemoryCache,
+        cache_key: cache_key,
         cache_policy: policy,
         fetcher: MockFetcher,
         fetcher_id: @fetcher_id,
         name: policy_id
       )
 
-    allow(MockCache, self(), policy_id)
     allow(MockFetcher, self(), policy_id)
 
     {:ok, policy_id}
   end
 
+  defp start_cache do
+    cache_key = UUID.uuid4()
+    {:ok, _pid} = InMemoryCache.start_link(cache_key: cache_key)
+
+    {:ok, cache_key}
+  end
+
   def expect_refresh(config) do
     MockFetcher
-    |> stub(:fetch, fn @fetcher_id -> {:ok, config} end)
-
-    MockCache
-    |> expect(:set, fn @cache_key, ^config -> :ok end)
+    |> expect(:fetch, fn @fetcher_id -> {:ok, config} end)
   end
 
   def expect_unchanged do
     MockFetcher
-    |> stub(:fetch, fn @fetcher_id -> {:ok, :unchanged} end)
-
-    MockCache
-    |> expect(:set, 0, fn @cache_key, _config -> :ok end)
+    |> expect(:fetch, fn @fetcher_id -> {:ok, :unchanged} end)
   end
 
   def expect_not_refreshed do
     MockFetcher
     |> expect(:fetch, 0, fn @fetcher_id -> {:ok, %{}} end)
-
-    MockCache
-    |> expect(:set, 0, fn @cache_key, _config -> :ok end)
   end
 
   def assert_returns_error(force_refresh_fn) do

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,4 +1,3 @@
 Mox.defmock(ConfigCat.MockAPI, for: HTTPoison.Base)
-Mox.defmock(ConfigCat.MockCache, for: ConfigCat.ConfigCache)
 Mox.defmock(ConfigCat.MockCachePolicy, for: ConfigCat.CachePolicy)
 Mox.defmock(ConfigCat.MockFetcher, for: ConfigCat.ConfigFetcher)


### PR DESCRIPTION
Closes #9 

The callback is called whenever the configuration changes, either by polling or a forced-refresh.

In order to test the on_changed callback feature, we need to use a real cache instead of a mock, because there doesn't seem to be a good way to mock the behavior we need correctly.