### PR TITLE
types: add typespecs

### DIFF
--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -1,20 +1,21 @@
 defmodule ConfigCat.CachePolicy do
-  alias ConfigCat.{ConfigCache, ConfigFetcher}
+  alias ConfigCat.{Config, ConfigCache, ConfigFetcher}
   alias __MODULE__.{Auto, Lazy, Manual}
 
+  @type id :: atom()
   @type option ::
           {:cache, module()}
           | {:cache_key, ConfigCache.key()}
           | {:cache_policy, t()}
+          | {:fetcher, module()}
           | {:fetcher_id, ConfigFetcher.id()}
-          | {:name, policy_id()}
+          | {:name, id()}
   @type options :: [option]
-  @type policy_id :: atom()
   @type refresh_result :: :ok | ConfigFetcher.fetch_error()
   @type t :: Auto.t() | Lazy.t() | Manual.t()
 
-  @callback get(policy_id()) :: {:ok, map()} | {:error, :not_found}
-  @callback force_refresh(policy_id()) :: refresh_result()
+  @callback get(id()) :: {:ok, Config.t()} | {:error, :not_found}
+  @callback force_refresh(id()) :: refresh_result()
 
   @spec auto(Auto.options()) :: Auto.t()
   def auto(options \\ []) do

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -1,35 +1,52 @@
 defmodule ConfigCat.CachePolicy do
-  @type policy_id :: atom()
-
-  @callback get(policy_id()) :: {:ok, map()} | {:error, :not_found}
-  @callback force_refresh(policy_id()) :: :ok | {:error, term()}
-
+  alias ConfigCat.{ConfigCache, ConfigFetcher}
   alias __MODULE__.{Auto, Lazy, Manual}
 
+  @type option ::
+          {:cache, module()}
+          | {:cache_key, ConfigCache.key()}
+          | {:cache_policy, t()}
+          | {:fetcher_id, ConfigFetcher.id()}
+          | {:name, policy_id()}
+  @type options :: [option]
+  @type policy_id :: atom()
+  @type refresh_result :: :ok | ConfigFetcher.fetch_error()
+  @type t :: Auto.t() | Lazy.t() | Manual.t()
+
+  @callback get(policy_id()) :: {:ok, map()} | {:error, :not_found}
+  @callback force_refresh(policy_id()) :: refresh_result()
+
+  @spec auto(Auto.options()) :: Auto.t()
   def auto(options \\ []) do
     Auto.new(options)
   end
 
+  @spec lazy(Lazy.options()) :: Lazy.t()
   def lazy(options) do
     Lazy.new(options)
   end
 
+  @spec manual :: Manual.t()
   def manual do
     Manual.new()
   end
 
+  @spec policy_name(t()) :: atom()
   def policy_name(%policy{}), do: policy
 
+  @spec policy_name(options()) :: atom()
   def policy_name(options) when is_list(options) do
     options
     |> Keyword.fetch!(:cache_policy)
     |> policy_name()
   end
 
+  @spec child_spec(options()) :: Supervisor.child_spec()
   def child_spec(options) do
     policy_name(options).child_spec(options)
   end
 
+  @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
     policy_name(options).start_link(options)
   end

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -32,10 +32,10 @@ defmodule ConfigCat.CachePolicy do
     Manual.new()
   end
 
-  @spec policy_name(t()) :: atom()
+  @spec policy_name(t()) :: module()
   def policy_name(%policy{}), do: policy
 
-  @spec policy_name(options()) :: atom()
+  @spec policy_name(options()) :: module()
   def policy_name(options) when is_list(options) do
     options
     |> Keyword.fetch!(:cache_policy)

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -18,11 +18,13 @@ defmodule ConfigCat.CachePolicy.Auto do
 
   @behaviour CachePolicy
 
+  @spec new(options()) :: t()
   def new(options \\ []) do
     struct(__MODULE__, options)
     |> Map.update!(:poll_interval_seconds, &max(&1, 1))
   end
 
+  @spec start_link(CachePolicy.options()) :: GenServer.on_start()
   def start_link(options) do
     Helpers.start_link(__MODULE__, options)
   end

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -8,6 +8,14 @@ defmodule ConfigCat.CachePolicy.Auto do
 
   defstruct mode: "a", on_changed: nil, poll_interval_seconds: 60
 
+  @type callback :: (() -> :ok)
+  @type options :: keyword() | map()
+  @type t :: %__MODULE__{
+          mode: String.t(),
+          on_changed: callback(),
+          poll_interval_seconds: pos_integer()
+        }
+
   @behaviour CachePolicy
 
   def new(options \\ []) do

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -1,4 +1,16 @@
 defmodule ConfigCat.CachePolicy.Helpers do
+  alias ConfigCat.{CachePolicy, ConfigCache, ConfigFetcher}
+
+  @type state :: %{
+          :cache => module(),
+          :cache_key => ConfigCache.key(),
+          :fetcher => module(),
+          :fetcher_id => ConfigFetcher.id(),
+          :name => CachePolicy.id(),
+          optional(atom()) => any()
+        }
+
+  @spec start_link(module(), CachePolicy.options(), map()) :: GenServer.on_start()
   def start_link(module, options, additional_state \\ %{}) do
     name = Keyword.fetch!(options, :name)
     initial_state = make_initial_state(options, additional_state)
@@ -23,6 +35,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
   defp default_options, do: [fetcher: ConfigCat.CacheControlConfigFetcher]
 
+  @spec cached_config(state()) :: ConfigCache.result()
   def cached_config(state) do
     cache = Map.fetch!(state, :cache)
     cache_key = Map.fetch!(state, :cache_key)
@@ -30,6 +43,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
     cache.get(cache_key)
   end
 
+  @spec refresh_config(state()) :: CachePolicy.refresh_result()
   def refresh_config(state) do
     fetcher = Map.fetch!(state, :fetcher)
     fetcher_id = Map.fetch!(state, :fetcher_id)

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -15,10 +15,12 @@ defmodule ConfigCat.CachePolicy.Lazy do
 
   @behaviour CachePolicy
 
+  @spec new(options()) :: t()
   def new(options) do
     struct(__MODULE__, options)
   end
 
+  @spec start_link(CachePolicy.options()) :: GenServer.on_start()
   def start_link(options) do
     Helpers.start_link(__MODULE__, options, %{last_update: nil})
   end

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -7,6 +7,12 @@ defmodule ConfigCat.CachePolicy.Lazy do
   @enforce_keys [:cache_expiry_seconds]
   defstruct [:cache_expiry_seconds, mode: "l"]
 
+  @type options :: keyword() | map()
+  @type t :: %__MODULE__{
+          cache_expiry_seconds: non_neg_integer(),
+          mode: String.t()
+        }
+
   @behaviour CachePolicy
 
   def new(options) do

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -10,10 +10,12 @@ defmodule ConfigCat.CachePolicy.Manual do
 
   @behaviour CachePolicy
 
+  @spec new :: t()
   def new do
     %__MODULE__{}
   end
 
+  @spec start_link(CachePolicy.options()) :: GenServer.on_start()
   def start_link(options) do
     Helpers.start_link(__MODULE__, options)
   end

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -6,6 +6,8 @@ defmodule ConfigCat.CachePolicy.Manual do
 
   defstruct mode: "m"
 
+  @type t :: %__MODULE__{mode: String.t()}
+
   @behaviour CachePolicy
 
   def new do

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -1,10 +1,13 @@
 defmodule ConfigCat.Client do
   use GenServer
 
-  alias ConfigCat.{Constants, Rollout}
+  alias ConfigCat.{CachePolicy, Constants, Rollout}
 
   require Constants
   require Logger
+
+  @type client :: atom()
+  @type refresh_result :: CachePolicy.refresh_result()
 
   def start_link(options) do
     with {name, options} <- Keyword.pop!(options, :name) do

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -1,32 +1,41 @@
 defmodule ConfigCat.Client do
   use GenServer
 
-  alias ConfigCat.{CachePolicy, Constants, Rollout}
+  alias ConfigCat.{CachePolicy, Config, Constants, Rollout, User}
 
   require Constants
   require Logger
 
   @type client :: atom()
+  @type option ::
+          {:cache_policy, module()} | {:cache_policy_id, CachePolicy.id()} | {:name, client()}
+  @type options :: [option]
   @type refresh_result :: CachePolicy.refresh_result()
 
+  @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
     with {name, options} <- Keyword.pop!(options, :name) do
       GenServer.start_link(__MODULE__, Map.new(options), name: name)
     end
   end
 
+  @spec get_all_keys(client()) :: [Config.key()]
   def get_all_keys(client) do
     GenServer.call(client, :get_all_keys)
   end
 
+  @spec get_value(client(), Config.key(), Config.value(), User.t() | nil) :: Config.value()
   def get_value(client, key, default_value, user \\ nil) do
     GenServer.call(client, {:get_value, key, default_value, user})
   end
 
+  @spec get_variation_id(client(), Config.key(), Config.variation_id(), User.t() | nil) ::
+          Config.variation_id()
   def get_variation_id(client, key, default_variation_id, user \\ nil) do
     GenServer.call(client, {:get_variation_id, key, default_variation_id, user})
   end
 
+  @spec force_refresh(client()) :: refresh_result()
   def force_refresh(client) do
     GenServer.call(client, :force_refresh)
   end

--- a/lib/config_cat/config.ex
+++ b/lib/config_cat/config.ex
@@ -1,4 +1,5 @@
 defmodule ConfigCat.Config do
+  @type comparator :: non_neg_integer()
   @type key :: String.t()
   # TODO: flesh this out
   @type t :: map()

--- a/lib/config_cat/config.ex
+++ b/lib/config_cat/config.ex
@@ -1,5 +1,7 @@
 defmodule ConfigCat.Config do
   @type key :: String.t()
+  # TODO: flesh this out
+  @type t :: map()
   @type value :: String.t() | boolean() | number()
   @type variation_id :: String.t()
 end

--- a/lib/config_cat/config.ex
+++ b/lib/config_cat/config.ex
@@ -1,7 +1,6 @@
 defmodule ConfigCat.Config do
   @type comparator :: non_neg_integer()
   @type key :: String.t()
-  # TODO: flesh this out
   @type t :: map()
   @type value :: String.t() | boolean() | number()
   @type variation_id :: String.t()

--- a/lib/config_cat/config.ex
+++ b/lib/config_cat/config.ex
@@ -1,0 +1,5 @@
+defmodule ConfigCat.Config do
+  @type key :: String.t()
+  @type value :: String.t() | boolean() | number()
+  @type variation_id :: String.t()
+end

--- a/lib/config_cat/config_cache.ex
+++ b/lib/config_cat/config_cache.ex
@@ -1,6 +1,6 @@
 defmodule ConfigCat.ConfigCache do
-  @type cache_key :: String.t()
+  @type key :: String.t()
 
-  @callback get(cache_key) :: {:ok, map()} | {:error, :not_found}
-  @callback set(cache_key, map()) :: :ok
+  @callback get(key) :: {:ok, map()} | {:error, :not_found}
+  @callback set(key, map()) :: :ok
 end

--- a/lib/config_cat/config_cache.ex
+++ b/lib/config_cat/config_cache.ex
@@ -1,6 +1,9 @@
 defmodule ConfigCat.ConfigCache do
-  @type key :: String.t()
+  alias ConfigCat.Config
 
-  @callback get(key) :: {:ok, map()} | {:error, :not_found}
-  @callback set(key, map()) :: :ok
+  @type key :: String.t()
+  @type result :: {:ok, Config.t()} | {:error, :not_found}
+
+  @callback get(key) :: {:ok, Config.t()} | {:error, :not_found}
+  @callback set(key, Config.t()) :: :ok
 end

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -1,9 +1,10 @@
 defmodule ConfigCat.ConfigFetcher do
+  alias ConfigCat.Config
   alias HTTPoison.{Error, Response}
 
   @type fetch_error :: {:error, Error.t() | Response.t()}
   @type id :: atom()
-  @type result :: {:ok, map()} | {:ok, :unchanged} | fetch_error()
+  @type result :: {:ok, Config.t()} | {:ok, :unchanged} | fetch_error()
 
   @callback fetch(id()) :: result()
 end

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -1,7 +1,11 @@
 defmodule ConfigCat.ConfigFetcher do
   alias HTTPoison.{Error, Response}
 
-  @callback fetch(atom()) :: {:ok, map()} | {:ok, :unchanged} | {:error, Error.t() | Response.t()}
+  @type fetch_error :: {:error, Error.t() | Response.t()}
+  @type id :: atom()
+  @type result :: {:ok, map()} | {:ok, :unchanged} | fetch_error()
+
+  @callback fetch(id()) :: result()
 end
 
 defmodule ConfigCat.CacheControlConfigFetcher do

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -18,8 +18,17 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   require ConfigCat.Constants
   require Logger
 
+  @type option ::
+          {:base_url, String.t()}
+          | {:http_proxy, String.t()}
+          | {:mode, String.t()}
+          | {:name, ConfigFetcher.id()}
+          | {:sdk_key, String.t()}
+  @type options :: [option]
+
   @behaviour ConfigFetcher
 
+  @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
     {name, options} = Keyword.pop!(options, :name)
 

--- a/lib/config_cat/in_memory_cache.ex
+++ b/lib/config_cat/in_memory_cache.ex
@@ -3,8 +3,12 @@ defmodule ConfigCat.InMemoryCache do
 
   alias ConfigCat.ConfigCache
 
+  @type option :: {:cache_key, ConfigCache.key()}
+  @type options :: [option]
+
   @behaviour ConfigCache
 
+  @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
     name =
       options

--- a/lib/config_cat/rollout.ex
+++ b/lib/config_cat/rollout.ex
@@ -1,9 +1,12 @@
 defmodule ConfigCat.Rollout do
+  alias ConfigCat.{Config, Constants, User}
+  alias ConfigCat.Rollout.Comparator
+
   require Logger
   require ConfigCat.Constants
 
-  alias ConfigCat.{Constants, User, Rollout.Comparator}
-
+  @spec evaluate(Config.key(), User.t() | nil, Config.value(), Config.variation_id(), Config.t()) ::
+          {Config.value(), Config.variation_id()}
   def evaluate(key, user, default_value, default_variation_id, config) do
     log_evaluating(key)
 
@@ -94,15 +97,15 @@ defmodule ConfigCat.Rollout do
     end
   end
 
-  def evaluate_percentage_rules(_percentage_rules = [], _user, _key), do: {:none, nil}
+  defp evaluate_percentage_rules(_percentage_rules = [], _user, _key), do: {:none, nil}
 
-  def evaluate_percentage_rules(percentage_rules, user, key) do
+  defp evaluate_percentage_rules(percentage_rules, user, key) do
     hash_val = hash_user(user, key)
 
     Enum.reduce_while(percentage_rules, {0, nil}, &evaluate_percentage_rule(&1, &2, hash_val))
   end
 
-  def evaluate_percentage_rule(rule, increment, hash_val) do
+  defp evaluate_percentage_rule(rule, increment, hash_val) do
     {bucket, _v} = increment
     bucket = increment_bucket(bucket, rule)
 

--- a/lib/config_cat/rollout/comparator.ex
+++ b/lib/config_cat/rollout/comparator.ex
@@ -1,4 +1,11 @@
 defmodule ConfigCat.Rollout.Comparator do
+  alias ConfigCat.Config
+  alias Version.InvalidVersionError
+
+  @type comparator :: Config.comparator()
+  @type description :: String.t()
+  @type result :: {:ok, boolean()} | {:error, Exception.t()}
+
   @is_one_of 0
   @is_not_one_of 1
   @contains 2
@@ -39,9 +46,12 @@ defmodule ConfigCat.Rollout.Comparator do
     @is_not_one_of_sensitive => "IS NOT ONE OF (Sensitive)"
   }
 
+  @spec description(comparator()) :: description()
   def description(comparator) do
     Map.get(@descriptions, comparator, "Unsupported comparator")
   end
+
+  @spec compare(comparator(), String.t(), String.t()) :: result()
 
   def compare(@is_one_of, user_value, comparison_value),
     do: is_one_of(user_value, comparison_value)
@@ -151,7 +161,7 @@ defmodule ConfigCat.Rollout.Comparator do
     result = Version.compare(user_version, comparison_version) in valid_comparisons
     {:ok, result}
   rescue
-    error in Version.InvalidVersionError -> {:error, error}
+    error in InvalidVersionError -> {:error, error}
   end
 
   defp to_version(value) do

--- a/lib/config_cat/user.ex
+++ b/lib/config_cat/user.ex
@@ -2,11 +2,22 @@ defmodule ConfigCat.User do
   @enforce_keys :identifier
   defstruct [:identifier, country: nil, email: nil, custom: %{}]
 
+  @type custom :: %{optional(String.t() | atom()) => String.t()}
+  @type options :: keyword() | map()
+  @type t :: %__MODULE__{
+          identifier: String.t(),
+          country: String.t() | nil,
+          email: String.t() | nil,
+          custom: custom()
+        }
+
+  @spec new(String.t(), options()) :: t()
   def new(identifier, other_props \\ []) do
     %__MODULE__{identifier: identifier}
     |> struct!(other_props)
   end
 
+  @spec get_attribute(t(), String.t()) :: String.t() | nil
   def get_attribute(user, attribute) do
     do_get_attribute(user, attribute)
   end

--- a/lib/config_cat/user.ex
+++ b/lib/config_cat/user.ex
@@ -1,6 +1,6 @@
 defmodule ConfigCat.User do
   @enforce_keys :identifier
-  defstruct [:identifier, country: nil, email: nil, custom: nil]
+  defstruct [:identifier, country: nil, email: nil, custom: %{}]
 
   def new(identifier, other_props \\ []) do
     %__MODULE__{identifier: identifier}
@@ -8,7 +8,7 @@ defmodule ConfigCat.User do
   end
 
   def get_attribute(user, attribute) do
-    do_get_attribute(user, normalize(attribute))
+    do_get_attribute(user, attribute)
   end
 
   defp do_get_attribute(user, "Identifier"), do: user.identifier
@@ -16,18 +16,12 @@ defmodule ConfigCat.User do
   defp do_get_attribute(user, "Email"), do: user.email
   defp do_get_attribute(user, attribute), do: custom_attribute(user.custom, attribute)
 
-  defp custom_attribute(nil, _attribute), do: nil
-
   defp custom_attribute(custom, attribute) do
     case Enum.find(custom, fn {key, _value} ->
-           normalize(key) == attribute
+           to_string(key) == attribute
          end) do
       {_key, value} -> value
       _ -> nil
     end
-  end
-
-  defp normalize(attribute) do
-    to_string(attribute)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule ConfigCat.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [
+        list_unused_filters: true,
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
       ]
     ]

--- a/test/config_cat/user_test.exs
+++ b/test/config_cat/user_test.exs
@@ -8,13 +8,13 @@ defmodule ConfigCat.UserTest do
       identifier = "IDENTIFIER"
       user = User.new(identifier)
 
-      assert %User{identifier: ^identifier, email: nil, country: nil, custom: nil} = user
+      assert %User{identifier: ^identifier, email: nil, country: nil, custom: %{}} = user
     end
 
     test "creates a user without any properties" do
       user = User.new(nil)
 
-      assert %User{identifier: nil, email: nil, country: nil, custom: nil} = user
+      assert %User{identifier: nil, email: nil, country: nil, custom: %{}} = user
     end
 
     test "creates a user with additional properties" do
@@ -23,7 +23,7 @@ defmodule ConfigCat.UserTest do
       country = "COUNTRY"
       user = User.new(identifier, email: email, country: country)
 
-      assert %User{identifier: ^identifier, email: ^email, country: ^country, custom: nil} = user
+      assert %User{identifier: ^identifier, email: ^email, country: ^country, custom: %{}} = user
     end
 
     test "creates a user with custom properties" do

--- a/test/rollout_test.exs
+++ b/test/rollout_test.exs
@@ -153,7 +153,7 @@ defmodule ConfigCat.RolloutTest do
     end
   end
 
-  defp build_custom(_custom_key, nil), do: nil
+  defp build_custom(_custom_key, nil), do: %{}
   defp build_custom(custom_key, custom_value), do: %{custom_key => custom_value}
 
   defp normalize(nil), do: nil


### PR DESCRIPTION
Closes #23 

Adds type specifications to all public functions in all modules (except for the callbacks in `api.ex`).

As much as possible, I tried to name specific types in each module rather than using primitive types everywhere.

I was going to provide a more detailed typespec for `Config.t()`, but since we don't control that spec here in our code, I chose to leave it as the more generic `map()`.  The Java client does roughly the same thing, typing it as a `JsonObject`.

In general, I explicitly listed the various `options` taken by a module, but for structs, I used the more generic `keyword() | map()` to avoid having to duplicate the fields in the struct, which are already listed out in the `t()` type.

I modified the User `custom` property to be an empty map by default rather than having to include an extra `nil` in the typespec.  Also, I marked the `identifier` property as required even though we handle the case where it's not provided. From the discussion in Slack, using `nil` there is discouraged but not disallowed; I figure we can at least provide a Dialyzer warning about it even if we handle it OK.

Refreshingly, adding the typespecs didn't expose any type errors in our code!  I was pleasantly surprised by that.