### PR TITLE
Features: Data Governance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ elixir:
 otp_release: '23.0'
 
 script:
+  - mix format --check-formatted
   - mix dialyzer
   - mix test
 

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -7,6 +7,7 @@ defmodule ConfigCat do
     Client,
     Config,
     Constants,
+    DataGovernance,
     InMemoryCache,
     User
   }
@@ -21,7 +22,7 @@ defmodule ConfigCat do
           | {:cache, module()}
           | {:cache_policy, CachePolicy.t()}
           | {:http_proxy, String.t()}
-          | {:data_governance, DataGovernance.id()}
+          | {:data_governance, DataGovernance.t()}
   @type options :: [option()]
   @type refresh_result :: Client.refresh_result()
   @type value :: Config.value()

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -21,8 +21,8 @@ defmodule ConfigCat do
           {:base_url, String.t()}
           | {:cache, module()}
           | {:cache_policy, CachePolicy.t()}
-          | {:http_proxy, String.t()}
           | {:data_governance, DataGovernance.t()}
+          | {:http_proxy, String.t()}
   @type options :: [option()]
   @type refresh_result :: Client.refresh_result()
   @type value :: Config.value()

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -21,6 +21,7 @@ defmodule ConfigCat do
           | {:cache, module()}
           | {:cache_policy, CachePolicy.t()}
           | {:http_proxy, String.t()}
+          | {:data_governance, DataGovernance.id()}
   @type options :: [option()]
   @type refresh_result :: Client.refresh_result()
   @type value :: Config.value()
@@ -188,6 +189,6 @@ defmodule ConfigCat do
     options
     |> Keyword.update!(:name, &fetcher_name/1)
     |> Keyword.put(:mode, options[:cache_policy].mode)
-    |> Keyword.take([:base_url, :http_proxy, :mode, :name, :sdk_key])
+    |> Keyword.take([:base_url, :http_proxy, :data_governance, :mode, :name, :sdk_key])
   end
 end

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -28,11 +28,11 @@ defmodule ConfigCat.CacheControlConfigFetcher do
 
   @type option ::
           {:base_url, String.t()}
+          | {:data_governance, DataGovernance.t()}
           | {:http_proxy, String.t()}
           | {:mode, String.t()}
           | {:name, ConfigFetcher.id()}
           | {:sdk_key, String.t()}
-          | {:data_governance, DataGovernance.t()}
   @type options :: [option]
 
   @behaviour ConfigFetcher

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -167,7 +167,8 @@ defmodule ConfigCat.CacheControlConfigFetcher do
               "Redirect loop during config.json fetch. Please contact support@configcat.com."
             )
 
-            state
+            # redirects needs reset as customers might change their configs at any time.
+            %{state | redirects: %{}}
 
           true ->
             state

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -153,7 +153,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
             state
 
           base_url && !followed? ->
-            {_, {_, _}, state} =
+            {_, _, state} =
               do_fetch(%{
                 state
                 | base_url: base_url,

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -32,7 +32,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
           | {:mode, String.t()}
           | {:name, ConfigFetcher.id()}
           | {:sdk_key, String.t()}
-          | {:data_governance, DataGovernance.id()}
+          | {:data_governance, DataGovernance.t()}
   @type options :: [option]
 
   @behaviour ConfigFetcher

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -144,7 +144,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
          redirect <- Map.get(p, Constants.redirect()) do
       followed? = Map.has_key?(redirects, new_base_url)
 
-      state =
+      new_state =
         cond do
           custom_endpoint? && redirect != RedirectMode.force_redirect() ->
             state
@@ -182,7 +182,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
         """)
       end
 
-      {:reply, {:ok, config}, %{state | etag: etag}}
+      {:reply, {:ok, config}, %{new_state | etag: etag}}
     end
   end
 

--- a/lib/config_cat/constants.ex
+++ b/lib/config_cat/constants.ex
@@ -1,9 +1,14 @@
 defmodule ConfigCat.Constants do
-  defmacro base_url, do: "https://cdn.configcat.com"
+  defmacro base_url_global, do: "https://cdn-global.configcat.com"
+  defmacro base_url_eu_only, do: "https://cdn-eu.configcat.com"
+
   defmacro base_path, do: "configuration-files"
   defmacro config_filename, do: "config_v5.json"
 
   defmacro feature_flags, do: "f"
+  defmacro preferences, do: "p"
+  defmacro preferences_base_url, do: "u"
+  defmacro redirect, do: "r"
   defmacro comparator, do: "t"
   defmacro comparison_attribute, do: "a"
   defmacro comparison_value, do: "c"

--- a/lib/config_cat/data_governance.ex
+++ b/lib/config_cat/data_governance.ex
@@ -1,4 +1,11 @@
 defmodule ConfigCat.DataGovernance do
+  @type t :: global | eu_only
+
+  @type eu_only :: integer()
+  @type global :: integer()
+
+  @spec global :: 0
   defmacro global, do: 0
+  @spec eu_only :: 1
   defmacro eu_only, do: 1
 end

--- a/lib/config_cat/data_governance.ex
+++ b/lib/config_cat/data_governance.ex
@@ -1,0 +1,4 @@
+defmodule ConfigCat.DataGovernance do
+  defmacro global, do: 0
+  defmacro eu_only, do: 1
+end

--- a/lib/config_cat/data_governance.ex
+++ b/lib/config_cat/data_governance.ex
@@ -1,11 +1,11 @@
 defmodule ConfigCat.DataGovernance do
+  @type eu_only :: 1
+  @type global :: 0
   @type t :: global | eu_only
 
-  @type eu_only :: integer()
-  @type global :: integer()
-
-  @spec global :: 0
+  @spec global :: global()
   defmacro global, do: 0
-  @spec eu_only :: 1
+
+  @spec eu_only :: eu_only()
   defmacro eu_only, do: 1
 end

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -34,7 +34,7 @@ defmodule ConfigCat.ConfigFetcherTest do
   test "successful fetch" do
     {:ok, fetcher} = start_fetcher(@fetcher_options)
 
-    url = global_config_url(@sdk_key)
+    url = global_config_url()
 
     MockAPI
     |> stub(:get, fn ^url, _headers, [] ->
@@ -157,12 +157,13 @@ defmodule ConfigCat.ConfigFetcherTest do
     {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  defp global_config_url(sdk_key) do
+  defp global_config_url(sdk_key \\ @sdk_key) do
     config_url(Constants.base_url_global(), sdk_key)
   end
 
   defp config_url(base_url, sdk_key) do
-    base_url |> URI.parse()
+    base_url
+    |> URI.parse()
     |> URI.merge("#{base_url}/#{Constants.base_path()}/#{sdk_key}/#{Constants.config_filename()}")
     |> URI.to_string()
   end

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -128,9 +128,10 @@ defmodule ConfigCat.ConfigFetcherTest do
     assert {:error, ^error} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "allows base URL to be configured", %{config: config, sdk_key: sdk_key} = context do
-    base_url = "https://BASE_URL"
-    {:ok, fetcher} = start_fetcher(context, base_url: base_url)
+  test "allows base URL to be configured" do
+    # the extra "/" at the end is intentional, to make sure it works regardless.
+    base_url = "https://BASE_URL/"
+    {:ok, fetcher} = start_fetcher(@fetcher_options, base_url: base_url)
 
     url = config_url(base_url, @sdk_key)
 
@@ -161,7 +162,9 @@ defmodule ConfigCat.ConfigFetcherTest do
   end
 
   defp config_url(base_url, sdk_key) do
-    "#{base_url}/#{Constants.base_path()}/#{sdk_key}/#{Constants.config_filename()}"
+    base_url |> URI.parse()
+    |> URI.merge("#{base_url}/#{Constants.base_path()}/#{sdk_key}/#{Constants.config_filename()}")
+    |> URI.to_string()
   end
 
   defp assert_user_agent_matches(headers, expected) do

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -269,7 +269,7 @@ defmodule ConfigCat.ConfigFetcherTest do
 
       redirect_url = config_url(redirect_path, sdk_key)
 
-      # First call: call global, no call should be made to the eu endpoint or the redirect one
+      # First call: call global, calls should be made normally
       MockAPI
       |> expect(:get, 1, fn ^eu_url, _headers, [] ->
         {:ok, %Response{status_code: 200, body: config}}

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -29,7 +29,6 @@ defmodule ConfigCat.ConfigFetcherTest do
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options \\ []) do
     name = UUID.uuid4() |> String.to_atom()
     default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
-    options = Keyword.merge(default_options, options)
 
     {:ok, _pid} =
       default_options

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -267,17 +267,16 @@ defmodule ConfigCat.ConfigFetcherTest do
         Map.get(config, Constants.preferences())
         |> Map.get(Constants.preferences_base_url())
 
-      redirect_url =
-        config_url(redirect_path, sdk_key)
+      redirect_url = config_url(redirect_path, sdk_key)
 
-        # First call: call global, no call should be made to the eu endpoint or the redirect one
-        MockAPI
-        |> expect(:get, 1, fn ^eu_url, _headers, [] ->
-          {:ok, %Response{status_code: 200, body: config}}
-        end)
-        |> expect(:get, 1, fn ^redirect_url, _headers, [] ->
-          {:ok, %Response{status_code: 200, body: config}}
-        end)
+      # First call: call global, no call should be made to the eu endpoint or the redirect one
+      MockAPI
+      |> expect(:get, 1, fn ^eu_url, _headers, [] ->
+        {:ok, %Response{status_code: 200, body: config}}
+      end)
+      |> expect(:get, 1, fn ^redirect_url, _headers, [] ->
+        {:ok, %Response{status_code: 200, body: config}}
+      end)
 
       assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
     end

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -228,7 +228,7 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     |> expect(:get, 1, fn ^custom_url, _headers, [] ->
       {:ok, %Response{status_code: 200, body: config_to_forced}}
     end)
-    |> expect(:get, 2, fn ^forced_url, _headers, [] ->
+    |> expect(:get, 3, fn ^forced_url, _headers, [] ->
       {:ok, %Response{status_code: 200, body: config_to_forced}}
     end)
 
@@ -249,11 +249,20 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     |> expect(:get, 1, fn ^global_url, _headers, [] ->
       {:ok, %Response{status_code: 200, body: config_to_eu}}
     end)
-    |> expect(:get, 2, fn ^eu_url, _headers, [] ->
+    |> expect(:get, 1, fn ^eu_url, _headers, [] ->
       {:ok, %Response{status_code: 200, body: config_to_global}}
     end)
 
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+
+    MockAPI
+    |> expect(:get, 1, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config_to_global}}
+    end)
+    |> expect(:get, 1, fn ^global_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config_to_eu}}
+    end)
+
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -13,17 +13,12 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
 
   setup :verify_on_exit!
 
-  setup do
-    {:ok,
-     %{
-       redirect_base_url: "https://redirect.configcat.com",
-       forced_base_url: "https://forced.configcat.com",
-       custom_base_url: "https://custom.configcat.com",
-       etag: "ETAG",
-       mode: "m",
-       sdk_key: "SDK_KEY"
-     }}
-  end
+  @redirect_base_url "https://redirect.configcat.com"
+  @forced_base_url "https://forced.configcat.com"
+  @custom_base_url "https://custom.configcat.com"
+  @mode "m"
+  @sdk_key "SDK_KEY"
+  @fetcher_options %{mode: @mode, sdk_key: @sdk_key}
 
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options) do
     name = UUID.uuid4() |> String.to_atom()
@@ -39,15 +34,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     {:ok, name}
   end
 
-  test "test_sdk_global_organization_global",
-       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
-    redirect_url = config_url(redirect_base_url, sdk_key)
+  test "test_sdk_global_organization_global" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
+    redirect_url = config_url(@redirect_base_url)
 
-    config = stub_response(redirect_base_url, RedirectMode.no_redirect())
+    config = stub_response(@redirect_base_url, RedirectMode.no_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+    {:ok, fetcher} = start_fetcher(@fetcher_options, data_governance: DataGovernance.global())
 
     MockAPI
     |> expect(:get, 2, fn ^global_url, _headers, [] ->
@@ -64,15 +58,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_eu_organization_global",
-       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
-    redirect_url = config_url(redirect_base_url, sdk_key)
+  test "test_sdk_eu_organization_global" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
+    redirect_url = config_url(@redirect_base_url)
 
-    config = stub_response(redirect_base_url, RedirectMode.no_redirect())
+    config = stub_response(@redirect_base_url, RedirectMode.no_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
+    {:ok, fetcher} = start_fetcher(@fetcher_options, data_governance: DataGovernance.eu_only())
 
     MockAPI
     |> expect(:get, 0, fn ^global_url, _headers, [] ->
@@ -89,15 +82,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_global_organization_eu_only",
-       %{sdk_key: sdk_key} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
+  test "test_sdk_global_organization_eu_only" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
 
     config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.should_redirect())
     config_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.no_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+    {:ok, fetcher} = start_fetcher(@fetcher_options, data_governance: DataGovernance.global())
 
     MockAPI
     |> expect(:get, 1, fn ^global_url, _headers, [] ->
@@ -111,15 +103,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_eu_organization_eu_only",
-       %{sdk_key: sdk_key} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
+  test "test_sdk_eu_organization_eu_only" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
 
     config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.should_redirect())
     config_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.no_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
+    {:ok, fetcher} = start_fetcher(@fetcher_options, data_governance: DataGovernance.eu_only())
 
     MockAPI
     |> expect(:get, 0, fn ^global_url, _headers, [] ->
@@ -133,16 +124,18 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_global_custom_base_url",
-       %{sdk_key: sdk_key, custom_base_url: custom_base_url} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
-    custom_url = config_url(custom_base_url, sdk_key)
+  test "test_sdk_global_custom_base_url" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
+    custom_url = config_url(@custom_base_url)
 
     config_to_global = stub_response(Constants.base_url_global(), RedirectMode.no_redirect())
 
     {:ok, fetcher} =
-      start_fetcher(context, data_governance: DataGovernance.global(), base_url: custom_base_url)
+      start_fetcher(@fetcher_options,
+        data_governance: DataGovernance.global(),
+        base_url: @custom_base_url
+      )
 
     MockAPI
     |> expect(:get, 2, fn ^custom_url, _headers, [] ->
@@ -159,16 +152,18 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_eu_custom_base_url",
-       %{sdk_key: sdk_key, custom_base_url: custom_base_url} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
-    custom_url = config_url(custom_base_url, sdk_key)
+  test "test_sdk_eu_custom_base_url" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
+    custom_url = config_url(@custom_base_url)
 
     config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.no_redirect())
 
     {:ok, fetcher} =
-      start_fetcher(context, data_governance: DataGovernance.eu_only(), base_url: custom_base_url)
+      start_fetcher(@fetcher_options,
+        data_governance: DataGovernance.eu_only(),
+        base_url: @custom_base_url
+      )
 
     MockAPI
     |> expect(:get, 2, fn ^custom_url, _headers, [] ->
@@ -185,15 +180,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_global_forced",
-       %{sdk_key: sdk_key, forced_base_url: forced_base_url} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
-    forced_url = config_url(forced_base_url, sdk_key)
+  test "test_sdk_global_forced" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
+    forced_url = config_url(@forced_base_url)
 
-    config_to_forced = stub_response(forced_base_url, RedirectMode.force_redirect())
+    config_to_forced = stub_response(@forced_base_url, RedirectMode.force_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+    {:ok, fetcher} = start_fetcher(@fetcher_options, data_governance: DataGovernance.global())
 
     MockAPI
     |> expect(:get, 1, fn ^global_url, _headers, [] ->
@@ -210,18 +204,19 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_base_url_forced",
-       %{sdk_key: sdk_key, custom_base_url: custom_base_url, forced_base_url: forced_base_url} =
-         context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
-    custom_url = config_url(custom_base_url, sdk_key)
-    forced_url = config_url(forced_base_url, sdk_key)
+  test "test_sdk_base_url_forced" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
+    custom_url = config_url(@custom_base_url)
+    forced_url = config_url(@forced_base_url)
 
-    config_to_forced = stub_response(forced_base_url, RedirectMode.force_redirect())
+    config_to_forced = stub_response(@forced_base_url, RedirectMode.force_redirect())
 
     {:ok, fetcher} =
-      start_fetcher(context, data_governance: DataGovernance.global(), base_url: custom_base_url)
+      start_fetcher(@fetcher_options,
+        data_governance: DataGovernance.global(),
+        base_url: @custom_base_url
+      )
 
     MockAPI
     |> expect(:get, 0, fn ^global_url, _headers, [] ->
@@ -241,15 +236,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
 
-  test "test_sdk_redirect_loop",
-       %{sdk_key: sdk_key} = context do
-    global_url = global_config_url(sdk_key)
-    eu_url = eu_config_url(sdk_key)
+  test "test_sdk_redirect_loop" do
+    global_url = global_config_url()
+    eu_url = eu_config_url()
 
     config_to_global = stub_response(Constants.base_url_global(), RedirectMode.should_redirect())
     config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.should_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+    {:ok, fetcher} = start_fetcher(@fetcher_options, data_governance: DataGovernance.global())
 
     MockAPI
     |> expect(:get, 1, fn ^global_url, _headers, [] ->
@@ -272,15 +266,15 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     }
   end
 
-  defp global_config_url(sdk_key) do
+  defp global_config_url(sdk_key \\ @sdk_key) do
     config_url(Constants.base_url_global(), sdk_key)
   end
 
-  defp eu_config_url(sdk_key) do
+  defp eu_config_url(sdk_key \\ @sdk_key) do
     config_url(Constants.base_url_eu_only(), sdk_key)
   end
 
-  defp config_url(base_url, sdk_key) do
+  defp config_url(base_url, sdk_key \\ @sdk_key) do
     "#{base_url}/#{Constants.base_path()}/#{sdk_key}/#{Constants.config_filename()}"
   end
 end

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -1,0 +1,271 @@
+defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias ConfigCat.CacheControlConfigFetcher, as: ConfigFetcher
+  alias ConfigCat.{Constants, DataGovernance, MockAPI}
+  alias ConfigCat.ConfigFetcher.RedirectMode
+  alias HTTPoison.Response
+
+  require ConfigCat.{Constants, DataGovernance}
+  require ConfigCat.ConfigFetcher.RedirectMode
+
+  setup :verify_on_exit!
+
+  setup do
+    config_with_redirect = %{
+      Constants.preferences() => %{
+        Constants.preferences_base_url() => "https://redirect.configcat.com",
+        Constants.redirect() => RedirectMode.should_redirect()
+      }
+    }
+
+    config_with_redirect = %{
+      Constants.preferences() => %{
+        Constants.preferences_base_url() => "https://redirect.configcat.com",
+        Constants.redirect() => RedirectMode.should_redirect()
+      }
+    }
+
+    config_with_force_redirect = %{
+      Constants.preferences() => %{
+        Constants.preferences_base_url() => "https://force.configcat.com",
+        Constants.redirect() => RedirectMode.force_redirect()
+      }
+    }
+
+    {:ok,
+     %{
+       redirect_base_url: "https://redirect.configcat.com",
+       force_base_url: "https://force.configcat.com",
+       custom_base_url: "https://custom.configcat.com",
+       config_with_redirect: config_with_redirect,
+       config_with_force_redirect: config_with_force_redirect,
+       etag: "ETAG",
+       mode: "m",
+       sdk_key: "SDK_KEY"
+     }}
+  end
+
+  defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options \\ []) do
+    name = UUID.uuid4() |> String.to_atom()
+    default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
+    options = Keyword.merge(default_options, options)
+
+    {:ok, _pid} =
+      default_options
+      |> Keyword.merge(options)
+      |> ConfigFetcher.start_link()
+
+    allow(MockAPI, self(), name)
+
+    {:ok, name}
+  end
+
+  test "test_sdk_global_organization_global",
+       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
+    global_url = global_config_url(sdk_key)
+    eu_url = eu_config_url(sdk_key)
+    redirect_url = config_url(redirect_base_url, sdk_key)
+
+    config = stub_response(redirect_base_url, RedirectMode.no_redirect())
+
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+
+    MockAPI
+    |> expect(:get, 2, fn ^global_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 0, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 0, fn ^redirect_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+  end
+
+  test "test_sdk_eu_organization_global",
+       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
+    global_url = global_config_url(sdk_key)
+    eu_url = eu_config_url(sdk_key)
+    redirect_url = config_url(redirect_base_url, sdk_key)
+
+    config = stub_response(redirect_base_url, RedirectMode.no_redirect())
+
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
+
+    MockAPI
+    |> expect(:get, 0, fn ^global_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 2, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 0, fn ^redirect_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+  end
+
+  test "test_sdk_global_organization_eu_only",
+       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
+    global_url = global_config_url(sdk_key)
+    eu_url = eu_config_url(sdk_key)
+
+    config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.should_redirect())
+    config_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.no_redirect())
+
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+
+    MockAPI
+    |> expect(:get, 1, fn ^global_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config_to_eu}}
+    end)
+    |> expect(:get, 2, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config_eu}}
+    end)
+
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+  end
+
+  test "test_sdk_eu_organization_eu_only",
+       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
+    global_url = global_config_url(sdk_key)
+    eu_url = eu_config_url(sdk_key)
+
+    config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.should_redirect())
+    config_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.no_redirect())
+
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+
+    MockAPI
+    |> expect(:get, 1, fn ^global_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config_to_eu}}
+    end)
+    |> expect(:get, 2, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config_eu}}
+    end)
+
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+  end
+
+  test "EU with redirection",
+       %{config_with_redirect: config, sdk_key: sdk_key} = context do
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
+
+    eu_url = eu_config_url(sdk_key)
+
+    redirect_path =
+      Map.get(config, Constants.preferences())
+      |> Map.get(Constants.preferences_base_url())
+
+    redirect_url = config_url(redirect_path, sdk_key)
+
+    # First call: call global-eu, then redirect
+    MockAPI
+    |> expect(:get, 1, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 1, fn ^redirect_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+
+    # Second call: only the redirected URL
+    MockAPI
+    |> expect(:get, 0, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 1, fn ^redirect_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+  end
+
+  test "redirection with custom endpoint",
+       %{config_with_redirect: config, sdk_key: sdk_key} = context do
+    base_url = "https://custom.service.net"
+
+    {:ok, fetcher} =
+      start_fetcher(context, data_governance: DataGovernance.eu_only(), base_url: base_url)
+
+    custom_url = config_url(base_url, sdk_key)
+    eu_url = eu_config_url(sdk_key)
+
+    redirect_path =
+      Map.get(config, Constants.preferences())
+      |> Map.get(Constants.preferences_base_url())
+
+    redirect_url = config_url(redirect_path, sdk_key)
+
+    # First call: call custom, no call should be made to the eu endpoint or the redirect one
+    MockAPI
+    |> expect(:get, 1, fn ^custom_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 0, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 0, fn ^redirect_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+  end
+
+  test "redirection with force redirect",
+       %{config_with_force_redirect: config, sdk_key: sdk_key} = context do
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
+
+    eu_url = eu_config_url(sdk_key)
+
+    redirect_path =
+      Map.get(config, Constants.preferences())
+      |> Map.get(Constants.preferences_base_url())
+
+    redirect_url = config_url(redirect_path, sdk_key)
+
+    # First call: call global, calls should be made normally
+    MockAPI
+    |> expect(:get, 1, fn ^eu_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+    |> expect(:get, 1, fn ^redirect_url, _headers, [] ->
+      {:ok, %Response{status_code: 200, body: config}}
+    end)
+
+    assert {:ok, ^config} = ConfigFetcher.fetch(fetcher)
+  end
+
+  defp stub_response(response_uri, redirect) do
+    %{
+      "f" => %{"test" => "json"},
+      Constants.preferences() => %{
+        Constants.preferences_base_url() => response_uri,
+        Constants.redirect() => redirect
+      }
+    }
+  end
+
+  defp global_config_url(sdk_key) do
+    config_url(Constants.base_url_global(), sdk_key)
+  end
+
+  defp eu_config_url(sdk_key) do
+    config_url(Constants.base_url_eu_only(), sdk_key)
+  end
+
+  defp config_url(base_url, sdk_key) do
+    "#{base_url}/#{Constants.base_path()}/#{sdk_key}/#{Constants.config_filename()}"
+  end
+end

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -14,34 +14,11 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
   setup :verify_on_exit!
 
   setup do
-    config_with_redirect = %{
-      Constants.preferences() => %{
-        Constants.preferences_base_url() => "https://redirect.configcat.com",
-        Constants.redirect() => RedirectMode.should_redirect()
-      }
-    }
-
-    config_with_redirect = %{
-      Constants.preferences() => %{
-        Constants.preferences_base_url() => "https://redirect.configcat.com",
-        Constants.redirect() => RedirectMode.should_redirect()
-      }
-    }
-
-    config_with_force_redirect = %{
-      Constants.preferences() => %{
-        Constants.preferences_base_url() => "https://force.configcat.com",
-        Constants.redirect() => RedirectMode.force_redirect()
-      }
-    }
-
     {:ok,
      %{
        redirect_base_url: "https://redirect.configcat.com",
-       force_base_url: "https://force.configcat.com",
+       forced_base_url: "https://forced.configcat.com",
        custom_base_url: "https://custom.configcat.com",
-       config_with_redirect: config_with_redirect,
-       config_with_force_redirect: config_with_force_redirect,
        etag: "ETAG",
        mode: "m",
        sdk_key: "SDK_KEY"
@@ -136,17 +113,17 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
   end
 
   test "test_sdk_eu_organization_eu_only",
-       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
+       %{sdk_key: sdk_key} = context do
     global_url = global_config_url(sdk_key)
     eu_url = eu_config_url(sdk_key)
 
     config_to_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.should_redirect())
     config_eu = stub_response(Constants.base_url_eu_only(), RedirectMode.no_redirect())
 
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.global())
+    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
 
     MockAPI
-    |> expect(:get, 1, fn ^global_url, _headers, [] ->
+    |> expect(:get, 0, fn ^global_url, _headers, [] ->
       {:ok, %Response{status_code: 200, body: config_to_eu}}
     end)
     |> expect(:get, 2, fn ^eu_url, _headers, [] ->

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -28,7 +28,6 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options) do
     name = UUID.uuid4() |> String.to_atom()
     default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
-    options = Keyword.merge(default_options, options)
 
     {:ok, _pid} =
       default_options
@@ -266,7 +265,6 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
 
   defp stub_response(response_uri, redirect) do
     %{
-      "f" => %{"test" => "json"},
       Constants.preferences() => %{
         Constants.preferences_base_url() => response_uri,
         Constants.redirect() => redirect

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -25,7 +25,7 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
      }}
   end
 
-  defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options \\ []) do
+  defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options) do
     name = UUID.uuid4() |> String.to_atom()
     default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
     options = Keyword.merge(default_options, options)
@@ -91,7 +91,7 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
   end
 
   test "test_sdk_global_organization_eu_only",
-       %{sdk_key: sdk_key, redirect_base_url: redirect_base_url} = context do
+       %{sdk_key: sdk_key} = context do
     global_url = global_config_url(sdk_key)
     eu_url = eu_config_url(sdk_key)
 
@@ -133,10 +133,6 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
     assert {:ok, _} = ConfigFetcher.fetch(fetcher)
   end
-
-  test "EU with redirection",
-       %{config_with_redirect: config, sdk_key: sdk_key} = context do
-    {:ok, fetcher} = start_fetcher(context, data_governance: DataGovernance.eu_only())
 
   test "test_sdk_global_custom_base_url",
        %{sdk_key: sdk_key, custom_base_url: custom_base_url} = context do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -64,7 +64,6 @@ defmodule ConfigCat.IntegrationTest do
     assert {:error, %HTTPoison.Error{}} = ConfigCat.force_refresh(client: client)
   end
 
-
   @tag capture_log: true
   test "handles data_governance: eu_only" do
     {:ok, client} = start_config_cat(@sdk_key, data_governance: DataGovernance.eu_only())

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,7 +1,8 @@
 defmodule ConfigCat.IntegrationTest do
   use ExUnit.Case, async: true
 
-  alias ConfigCat.CachePolicy
+  require ConfigCat.{DataGovernance}
+  alias ConfigCat.{CachePolicy, DataGovernance}
 
   @sdk_key "PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA"
 
@@ -61,6 +62,15 @@ defmodule ConfigCat.IntegrationTest do
     {:ok, client} = start_config_cat(@sdk_key, base_url: "https://invalidcdn.configcat.com")
 
     assert {:error, %HTTPoison.Error{}} = ConfigCat.force_refresh(client: client)
+  end
+
+
+  @tag capture_log: true
+  test "handles data_governance: eu_only" do
+    {:ok, client} = start_config_cat(@sdk_key, data_governance: DataGovernance.eu_only())
+
+    assert ConfigCat.get_value("keySampleText", "default value", client: client) ==
+             "This text came from ConfigCat"
   end
 
   defp start_config_cat(sdk_key, options \\ []) do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -1,7 +1,7 @@
 defmodule ConfigCat.IntegrationTest do
   use ExUnit.Case, async: true
 
-  require ConfigCat.{DataGovernance}
+  require ConfigCat.DataGovernance
   alias ConfigCat.{CachePolicy, DataGovernance}
 
   @sdk_key "PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA"


### PR DESCRIPTION
Addresses #13 

1. Adding mix format CI validation.
1. Validates the inner config options `"p"."u"` and `"p"."r"`.
1. If the user decides to set its own base_url, data governance is ignored unless `"p"."r"` is FORCE.
1. Converted a few inner data structures to Map instead of lists so we can handle user overwrites more easily.
1. I tried to do all Map manipulations with O(1) time complexity.
1. Not using anymore the address `https://cdn.configcat.com` in favor of `cdn-eu` and `cdn-global`.
1. Test cases matches the Ruby SDK 

