### PR TITLE
feat: support remaining variation functions

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -133,6 +133,12 @@ defmodule ConfigCat do
     Client.get_all_variation_ids(client_name(name), user)
   end
 
+  @spec get_key_and_value(variation_id(), [api_option()]) :: {key(), value()} | nil
+  def get_key_and_value(variation_id, options \\ []) do
+    name = Keyword.get(options, :client, __MODULE__)
+    Client.get_key_and_value(client_name(name), variation_id)
+  end
+
   @spec force_refresh([api_option()]) :: refresh_result()
   def force_refresh(options \\ []) do
     name = Keyword.get(options, :client, __MODULE__)

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -118,6 +118,21 @@ defmodule ConfigCat do
     Client.get_variation_id(client_name(name), key, default_variation_id, user)
   end
 
+  @spec get_all_variation_ids(User.t() | [api_option()]) :: [variation_id()]
+  def get_all_variation_ids(user_or_options \\ []) do
+    if Keyword.keyword?(user_or_options) do
+      get_all_variation_ids(nil, user_or_options)
+    else
+      get_all_variation_ids(user_or_options, [])
+    end
+  end
+
+  @spec get_all_variation_ids(User.t() | nil, [api_option()]) :: [variation_id()]
+  def get_all_variation_ids(user, options) do
+    name = Keyword.get(options, :client, __MODULE__)
+    Client.get_all_variation_ids(client_name(name), user)
+  end
+
   @spec force_refresh([api_option()]) :: refresh_result()
   def force_refresh(options \\ []) do
     name = Keyword.get(options, :client, __MODULE__)

--- a/lib/config_cat/constants.ex
+++ b/lib/config_cat/constants.ex
@@ -1,5 +1,4 @@
 defmodule ConfigCat.Constants do
-
   defmacro base_url, do: "https://cdn.configcat.com"
   defmacro base_path, do: "configuration-files"
   defmacro config_filename, do: "config_v5.json"
@@ -13,5 +12,4 @@ defmodule ConfigCat.Constants do
   defmacro percentage, do: "p"
   defmacro value, do: "v"
   defmacro variation_id, do: "i"
-
 end

--- a/test/config_cat/client_test.exs
+++ b/test/config_cat/client_test.exs
@@ -75,12 +75,10 @@ defmodule ConfigCat.ClientTest do
                "default_variation_id"
     end
 
-    test "get_variation_id/4 looks up the variation id for a key", %{
-      client: client,
-      feature: feature,
-      variation: variation
-    } do
-      assert Client.get_variation_id(client, feature, "default") == variation
+    test "get_all_variation_ids/1 returns all known variation ids", %{client: client} do
+      expected = ~w(fakeId1 fakeId2) |> Enum.sort()
+      actual = client |> Client.get_all_variation_ids() |> Enum.sort()
+      assert actual == expected
     end
   end
 
@@ -104,6 +102,10 @@ defmodule ConfigCat.ClientTest do
 
     test "get_variation_id/4 returns default variation", %{client: client} do
       assert Client.get_variation_id(client, "any_feature", "default") == "default"
+    end
+
+    test "get_all_variation_ids/2 returns an empty list of variation ids", %{client: client} do
+      assert Client.get_all_variation_ids(client) == []
     end
   end
 

--- a/test/config_cat/client_test.exs
+++ b/test/config_cat/client_test.exs
@@ -3,29 +3,28 @@ defmodule ConfigCat.ClientTest do
 
   import Mox
 
-  alias ConfigCat.{Client, Constants, MockCachePolicy}
-
-  require ConfigCat.Constants
+  alias ConfigCat.{Client, MockCachePolicy}
 
   @cache_policy_id :cache_policy_id
 
   setup :verify_on_exit!
 
   setup do
-    feature = "FEATURE"
-    value = "VALUE"
-    variation = "VARIATION"
-
-    config = %{
-      Constants.feature_flags() => %{
-        feature => %{
-          Constants.variation_id() => variation,
-          Constants.value() => value
+    config = Jason.decode!(~s(
+      {
+        "p": {"u": "https://cdn-global.configcat.com", "r": 0},
+        "f": {
+          "testBoolKey": {"v": true,"t": 0, "p": [],"r": []},
+          "testStringKey": {"v": "testValue","t": 1, "p": [],"r": []},
+          "testIntKey": {"v": 1,"t": 2, "p": [],"r": []},
+          "testDoubleKey": {"v": 1.1,"t": 3,"p": [],"r": []},
+          "key1": {"v": true, "i": "fakeId1","p": [], "r": []},
+          "key2": {"v": false, "i": "fakeId2","p": [], "r": []}
         }
       }
-    }
+    ))
 
-    {:ok, config: config, feature: feature, value: value, variation: variation}
+    {:ok, config: config}
   end
 
   describe "when the configuration has been fetched" do
@@ -38,19 +37,42 @@ defmodule ConfigCat.ClientTest do
       {:ok, client: client}
     end
 
-    test "get_all_keys/1 returns all known keys", %{
-      client: client,
-      feature: feature
-    } do
-      assert Client.get_all_keys(client) == [feature]
+    test "get_all_keys/1 returns all known keys", %{client: client} do
+      expected = ~w(testBoolKey testStringKey testIntKey testDoubleKey key1 key2) |> Enum.sort()
+      actual = client |> Client.get_all_keys() |> Enum.sort()
+      assert actual == expected
     end
 
-    test "get_value/4 looks up the value for a key", %{
-      client: client,
-      feature: feature,
-      value: value
-    } do
-      assert Client.get_value(client, feature, "default") == value
+    test "get_value/4 returns a boolean value", %{client: client} do
+      assert Client.get_value(client, "testBoolKey", false) == true
+    end
+
+    test "get_value/4 returns a string value", %{client: client} do
+      assert Client.get_value(client, "testStringKey", "default") == "testValue"
+    end
+
+    test "get_value/4 returns an integer value", %{client: client} do
+      assert Client.get_value(client, "testIntKey", 0) == 1
+    end
+
+    test "get_value/4 returns a double value", %{client: client} do
+      assert Client.get_value(client, "testDoubleKey", 0.0) == 1.1
+    end
+
+    @tag capture_log: true
+    test "get_value/4 returns default value if key not found", %{client: client} do
+      assert Client.get_value(client, "testUnknownKey", "default") == "default"
+    end
+
+    test "get_variation_id/4 looks up the variation id for a key", %{client: client} do
+      assert Client.get_variation_id(client, "key1", nil) == "fakeId1"
+      assert Client.get_variation_id(client, "key2", nil) == "fakeId2"
+    end
+
+    @tag capture_log: true
+    test "get_variation_id/4 returns default if variation id not found", %{client: client} do
+      assert Client.get_variation_id(client, "nonexisting", "default_variation_id") ==
+               "default_variation_id"
     end
 
     test "get_variation_id/4 looks up the variation id for a key", %{

--- a/test/config_cat/client_test.exs
+++ b/test/config_cat/client_test.exs
@@ -80,6 +80,13 @@ defmodule ConfigCat.ClientTest do
       actual = client |> Client.get_all_variation_ids() |> Enum.sort()
       assert actual == expected
     end
+
+    test "get_key_and_value/2 returns matching key/value pair for a variation id", %{
+      client: client
+    } do
+      assert {"key1", true} = Client.get_key_and_value(client, "fakeId1")
+      assert {"key2", false} = Client.get_key_and_value(client, "fakeId2")
+    end
   end
 
   describe "when the configuration has not been fetched" do
@@ -106,6 +113,11 @@ defmodule ConfigCat.ClientTest do
 
     test "get_all_variation_ids/2 returns an empty list of variation ids", %{client: client} do
       assert Client.get_all_variation_ids(client) == []
+    end
+
+    @tag capture_log: true
+    test "get_key_and_value/2 returns nil", %{client: client} do
+      assert Client.get_key_and_value(client, "any_variation") == nil
     end
   end
 


### PR DESCRIPTION
Closes #36 

Adds support for `get_all_variation_ids` and `get_key_and_value`.

As part of this, I modified the `Client` tests to more closely match the Ruby specs as the sample config used there has the extra elements we need to test the new functions.

I also formatted the `Constants` file so that it will pass the new `mix format --check-formatted` that's coming in #47.