### PR TITLE
refactor: extract CachePolicy behaviour to private module

### DIFF
--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -11,6 +11,7 @@ defmodule ConfigCat.CachePolicy do
           | {:fetcher_id, ConfigFetcher.id()}
           | {:name, id()}
   @type options :: [option]
+  @type refresh_result :: :ok | ConfigFetcher.fetch_error()
   @type t :: Auto.t() | Lazy.t() | Manual.t()
 
   @spec auto(Auto.options()) :: Auto.t()

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -1,5 +1,5 @@
 defmodule ConfigCat.CachePolicy do
-  alias ConfigCat.{Config, ConfigCache, ConfigFetcher}
+  alias ConfigCat.{ConfigCache, ConfigFetcher}
   alias __MODULE__.{Auto, Lazy, Manual}
 
   @type id :: atom()
@@ -11,11 +11,7 @@ defmodule ConfigCat.CachePolicy do
           | {:fetcher_id, ConfigFetcher.id()}
           | {:name, id()}
   @type options :: [option]
-  @type refresh_result :: :ok | ConfigFetcher.fetch_error()
   @type t :: Auto.t() | Lazy.t() | Manual.t()
-
-  @callback get(id()) :: {:ok, Config.t()} | {:error, :not_found}
-  @callback force_refresh(id()) :: refresh_result()
 
   @spec auto(Auto.options()) :: Auto.t()
   def auto(options \\ []) do

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -2,7 +2,7 @@ defmodule ConfigCat.CachePolicy.Auto do
   use GenServer
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Helpers
+  alias ConfigCat.CachePolicy.{Behaviour, Helpers}
 
   require Logger
 
@@ -16,7 +16,7 @@ defmodule ConfigCat.CachePolicy.Auto do
           poll_interval_seconds: pos_integer()
         }
 
-  @behaviour CachePolicy
+  @behaviour Behaviour
 
   @spec new(options()) :: t()
   def new(options \\ []) do
@@ -44,12 +44,12 @@ defmodule ConfigCat.CachePolicy.Auto do
     polled_refresh(state)
   end
 
-  @impl CachePolicy
+  @impl Behaviour
   def get(policy_id) do
     GenServer.call(policy_id, :get)
   end
 
-  @impl CachePolicy
+  @impl Behaviour
   def force_refresh(policy_id) do
     GenServer.call(policy_id, :force_refresh)
   end

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -1,8 +1,8 @@
 defmodule ConfigCat.CachePolicy.Behaviour do
-  alias ConfigCat.{CachePolicy, Config, ConfigFetcher}
+  alias ConfigCat.{CachePolicy, Config}
 
   @type id :: CachePolicy.id()
-  @type refresh_result :: :ok | ConfigFetcher.fetch_error()
+  @type refresh_result :: CachePolicy.refresh_result()
 
   @callback get(id()) :: {:ok, Config.t()} | {:error, :not_found}
   @callback force_refresh(id()) :: refresh_result()

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -1,0 +1,9 @@
+defmodule ConfigCat.CachePolicy.Behaviour do
+  alias ConfigCat.{CachePolicy, Config, ConfigFetcher}
+
+  @type id :: CachePolicy.id()
+  @type refresh_result :: :ok | ConfigFetcher.fetch_error()
+
+  @callback get(id()) :: {:ok, Config.t()} | {:error, :not_found}
+  @callback force_refresh(id()) :: refresh_result()
+end

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -2,7 +2,7 @@ defmodule ConfigCat.CachePolicy.Lazy do
   use GenServer
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Helpers
+  alias ConfigCat.CachePolicy.{Behaviour, Helpers}
 
   @enforce_keys [:cache_expiry_seconds]
   defstruct [:cache_expiry_seconds, mode: "l"]
@@ -13,7 +13,7 @@ defmodule ConfigCat.CachePolicy.Lazy do
           mode: String.t()
         }
 
-  @behaviour CachePolicy
+  @behaviour Behaviour
 
   @spec new(options()) :: t()
   def new(options) do
@@ -30,12 +30,12 @@ defmodule ConfigCat.CachePolicy.Lazy do
     {:ok, state}
   end
 
-  @impl CachePolicy
+  @impl Behaviour
   def get(policy_id) do
     GenServer.call(policy_id, :get)
   end
 
-  @impl CachePolicy
+  @impl Behaviour
   def force_refresh(policy_id) do
     GenServer.call(policy_id, :force_refresh)
   end

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -2,13 +2,13 @@ defmodule ConfigCat.CachePolicy.Manual do
   use GenServer
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Helpers
+  alias ConfigCat.CachePolicy.{Behaviour, Helpers}
 
   defstruct mode: "m"
 
   @type t :: %__MODULE__{mode: String.t()}
 
-  @behaviour CachePolicy
+  @behaviour Behaviour
 
   @spec new :: t()
   def new do
@@ -25,12 +25,12 @@ defmodule ConfigCat.CachePolicy.Manual do
     {:ok, state}
   end
 
-  @impl CachePolicy
+  @impl Behaviour
   def get(policy_id) do
     GenServer.call(policy_id, :get)
   end
 
-  @impl CachePolicy
+  @impl Behaviour
   def force_refresh(policy_id) do
     GenServer.call(policy_id, :force_refresh)
   end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,3 +1,3 @@
 Mox.defmock(ConfigCat.MockAPI, for: HTTPoison.Base)
-Mox.defmock(ConfigCat.MockCachePolicy, for: ConfigCat.CachePolicy)
+Mox.defmock(ConfigCat.MockCachePolicy, for: ConfigCat.CachePolicy.Behaviour)
 Mox.defmock(ConfigCat.MockFetcher, for: ConfigCat.ConfigFetcher)


### PR DESCRIPTION
When working on the Hex docs, I found that ex_doc was documenting CachePolicy as a behaviour and I couldn't hide that part of the docs, even though we want it to be private.

This extracts the callbacks and private types to a separate `CachePolicy.Behaviour` module to avoid the problem.

This is actually a bit clearer now, because CachePolicy was serving as both the behaviour for the implementations and as a public-facing facade for working with cache policies.  Now, each responsibility is in its own module.