### PR TITLE
fix: prevent genserver calls from timing out during config fetch

### DIFF
--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -3,8 +3,10 @@ defmodule ConfigCat.CachePolicy.Lazy do
 
   use GenServer
 
-  alias ConfigCat.CachePolicy
+  alias ConfigCat.{CachePolicy, Constants}
   alias ConfigCat.CachePolicy.{Behaviour, Helpers}
+
+  require Constants
 
   @enforce_keys [:cache_expiry_seconds]
   defstruct [:cache_expiry_seconds, mode: "l"]
@@ -34,12 +36,12 @@ defmodule ConfigCat.CachePolicy.Lazy do
 
   @impl Behaviour
   def get(policy_id) do
-    GenServer.call(policy_id, :get)
+    GenServer.call(policy_id, :get, Constants.fetch_timeout())
   end
 
   @impl Behaviour
   def force_refresh(policy_id) do
-    GenServer.call(policy_id, :force_refresh)
+    GenServer.call(policy_id, :force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -3,8 +3,10 @@ defmodule ConfigCat.CachePolicy.Manual do
 
   use GenServer
 
-  alias ConfigCat.CachePolicy
+  alias ConfigCat.{CachePolicy, Constants}
   alias ConfigCat.CachePolicy.{Behaviour, Helpers}
+
+  require Constants
 
   defstruct mode: "m"
 
@@ -34,7 +36,7 @@ defmodule ConfigCat.CachePolicy.Manual do
 
   @impl Behaviour
   def force_refresh(policy_id) do
-    GenServer.call(policy_id, :force_refresh)
+    GenServer.call(policy_id, :force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -23,33 +23,37 @@ defmodule ConfigCat.Client do
 
   @spec get_all_keys(client()) :: [Config.key()]
   def get_all_keys(client) do
-    GenServer.call(client, :get_all_keys)
+    GenServer.call(client, :get_all_keys, Constants.fetch_timeout())
   end
 
   @spec get_value(client(), Config.key(), Config.value(), User.t() | nil) :: Config.value()
   def get_value(client, key, default_value, user \\ nil) do
-    GenServer.call(client, {:get_value, key, default_value, user})
+    GenServer.call(client, {:get_value, key, default_value, user}, Constants.fetch_timeout())
   end
 
   @spec get_variation_id(client(), Config.key(), Config.variation_id(), User.t() | nil) ::
           Config.variation_id()
   def get_variation_id(client, key, default_variation_id, user \\ nil) do
-    GenServer.call(client, {:get_variation_id, key, default_variation_id, user})
+    GenServer.call(
+      client,
+      {:get_variation_id, key, default_variation_id, user},
+      Constants.fetch_timeout()
+    )
   end
 
   @spec get_all_variation_ids(client(), User.t() | nil) :: [Config.variation_id()]
   def get_all_variation_ids(client, user \\ nil) do
-    GenServer.call(client, {:get_all_variation_ids, user})
+    GenServer.call(client, {:get_all_variation_ids, user}, Constants.fetch_timeout())
   end
 
   @spec get_key_and_value(client(), Config.variation_id()) :: {Config.key(), Config.value()} | nil
   def get_key_and_value(client, variation_id) do
-    GenServer.call(client, {:get_key_and_value, variation_id})
+    GenServer.call(client, {:get_key_and_value, variation_id}, Constants.fetch_timeout())
   end
 
   @spec force_refresh(client()) :: refresh_result()
   def force_refresh(client) do
-    GenServer.call(client, :force_refresh)
+    GenServer.call(client, :force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -28,8 +28,8 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   alias ConfigFetcher.RedirectMode
   alias HTTPoison.Response
 
-  require ConfigCat.Constants
-  require ConfigFetcher.RedirectMode
+  require Constants
+  require RedirectMode
   require Logger
 
   @type option ::
@@ -76,7 +76,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
 
   @impl ConfigFetcher
   def fetch(fetcher) do
-    GenServer.call(fetcher, :fetch)
+    GenServer.call(fetcher, :fetch, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/constants.ex
+++ b/lib/config_cat/constants.ex
@@ -19,4 +19,5 @@ defmodule ConfigCat.Constants do
   defmacro percentage, do: "p"
   defmacro value, do: "v"
   defmacro variation_id, do: "i"
+  defmacro fetch_timeout, do: 10_000
 end


### PR DESCRIPTION
### Related issues
Closes #61  (Getting a GenServer timeout when refreshing config)

### Describe the solution you've provided

In order to get fewer GenServer timeouts, this will provide an increased timeout to the `Genserver.call` functions that rely upon the network request. 

For the `lazy` and `manual` cache policies, we added the increased timeouts and the policy.get functions will still be blocked on fetching the config. For the `auto` policy, the initial fetch is blocked on the refreshing of the config. However, for the subsequent poll refreshes, the refresh is put into a separate Task process so that it does not block the caller. So when the GenServer starts up, if `Auto.get/1` is called before the the fetching of the config is finished, he message will not be handled until after the fetching is finished. However, if it is not the initial fetch and `Auto.get/1` is called while the refresh config is refreshing, it will not wait for the refresh and instead just use the value of the cached config.

### Requirement checklist

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
