### PR TITLE
✨ Flag overrides

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -82,6 +82,13 @@ defmodule ConfigCat do
     {ConfigCat, [sdk_key: "YOUR SDK KEY", cache_policy: ConfigCat.CachePolicy.manual()]}
     ```
 
+  - `connect_timeout`: **OPTIONAL** timeout for establishing a TCP or SSL connection,
+    in milliseconds. Default is 8000.
+
+    ```elixir
+    {ConfigCat, [sdk_key: "YOUR SDK KEY", connect_timeout: 8000]}
+    ```
+
   - `data_governance`: **OPTIONAL** Describes the location of your feature flag
     and setting data within the ConfigCat CDN. This parameter needs to be in
     sync with your Data Governance preferences.  Defaults to `:global`. [More
@@ -91,6 +98,12 @@ defmodule ConfigCat do
     {ConfigCat, [sdk_key: "YOUR SDK KEY", data_governance: :eu_only]}
     ```
 
+  - `flag_overrides`: **OPTIONAL** Specify a data source to use for [local flag
+    overrides](https://configcat.com/docs/sdk-reference/elixir#flag-overrides).
+    The data source must implement the `ConfigCat.OverrideDataSource` protocol.
+    `ConfigCat.LocalFileDataSource` and `ConfigCat.LocalMapDataSource` are
+    provided for you to use.
+
   - `http_proxy`: **OPTIONAL** Specify this option if you need to use a proxy
     server to access your ConfigCat settings. You can provide a simple URL, like
     `https://my_proxy.example.com` or include authentication information, like
@@ -98,20 +111,6 @@ defmodule ConfigCat do
 
     ```elixir
     {ConfigCat, [sdk_key: "YOUR SDK KEY", http_proxy: "https://my_proxy.example.com"]}
-    ```
-
-  - `connect_timeout`: **OPTIONAL** timeout for establishing a TCP or SSL connection,
-    in milliseconds. Default is 8000.
-
-    ```elixir
-    {ConfigCat, [sdk_key: "YOUR SDK KEY", connect_timeout: 8000]}
-    ```
-
-  - `read_timeout`: **OPTIONAL** timeout for receiving an HTTP response from
-    the socket, in milliseconds. Default is 5000
-
-    ```elixir
-    {ConfigCat, [sdk_key: "YOUR SDK KEY", read_timeout: 5000]}
     ```
 
   - `name`: **OPTIONAL** A unique identifier for this instance of `ConfigCat`.
@@ -126,6 +125,13 @@ defmodule ConfigCat do
 
     ```elixir
     ConfigCat.get_value("setting", "default", client: :unique_name)
+    ```
+
+  - `read_timeout`: **OPTIONAL** timeout for receiving an HTTP response from
+    the socket, in milliseconds. Default is 5000
+
+    ```elixir
+    {ConfigCat, [sdk_key: "YOUR SDK KEY", read_timeout: 5000]}
     ```
 
   ## Use the API
@@ -158,6 +164,7 @@ defmodule ConfigCat do
     Config,
     Constants,
     InMemoryCache,
+    OverrideDataSource,
     User
   }
 
@@ -184,11 +191,12 @@ defmodule ConfigCat do
           {:base_url, String.t()}
           | {:cache, module()}
           | {:cache_policy, CachePolicy.t()}
-          | {:data_governance, data_governance()}
-          | {:http_proxy, String.t()}
           | {:connect_timeout, non_neg_integer()}
-          | {:read_timeout, non_neg_integer()}
+          | {:data_governance, data_governance()}
+          | {:flag_overrides, OverrideDataSource.t()}
+          | {:http_proxy, String.t()}
           | {:name, instance_id()}
+          | {:read_timeout, non_neg_integer()}
           | {:sdk_key, String.t()}
 
   @type options :: [option()]
@@ -477,6 +485,7 @@ defmodule ConfigCat do
     |> Keyword.take([
       :cache_policy,
       :cache_policy_id,
+      :flag_overrides,
       :name
     ])
   end

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -7,7 +7,6 @@ defmodule ConfigCat.Client do
     CachePolicy,
     Config,
     Constants,
-    NullDataSource,
     OverrideDataSource,
     Rollout,
     User
@@ -28,12 +27,7 @@ defmodule ConfigCat.Client do
   @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
     with {name, options} <- Keyword.pop!(options, :name) do
-      initial_state =
-        options
-        |> Map.new()
-        |> Map.put_new_lazy(:flag_overrides, &NullDataSource.new/0)
-
-      GenServer.start_link(__MODULE__, initial_state, name: name)
+      GenServer.start_link(__MODULE__, Map.new(options), name: name)
     end
   end
 

--- a/lib/config_cat/local_file_data_source.ex
+++ b/lib/config_cat/local_file_data_source.ex
@@ -10,6 +10,8 @@ defmodule ConfigCat.LocalFileDataSource do
   require Logger
 
   defmodule FileCache do
+    @moduledoc false
+
     use Agent
 
     defstruct cached_timestamp: 0, settings: nil
@@ -38,6 +40,16 @@ defmodule ConfigCat.LocalFileDataSource do
 
   defstruct [:cache, :filename, :override_behaviour]
 
+  @type t :: %__MODULE__{
+          cache: pid,
+          filename: String.t(),
+          override_behaviour: OverrideDataSource.behaviour()
+        }
+
+  @doc """
+  Create a `ConfigCat.OverrideDataSource` that loads overrides from a file.
+  """
+  @spec new(String.t(), OverrideDataSource.behaviour()) :: t
   def new(filename, override_behaviour) do
     unless File.exists?(filename) do
       Logger.error("The file #{filename} does not exist.")

--- a/lib/config_cat/local_file_data_source.ex
+++ b/lib/config_cat/local_file_data_source.ex
@@ -1,0 +1,61 @@
+defmodule ConfigCat.LocalFileDataSource do
+  @moduledoc """
+  Load flag overrides from a file.
+
+  See `ConfigCat.OverrideDataSource` for more details.
+  """
+
+  alias ConfigCat.OverrideDataSource
+
+  require Logger
+
+  defstruct [:filename, :override_behaviour]
+
+  def new(filename, override_behaviour) do
+    unless File.exists?(filename) do
+      Logger.error("The file #{filename} does not exist.")
+    end
+
+    %__MODULE__{filename: filename, override_behaviour: override_behaviour}
+  end
+
+  defimpl OverrideDataSource do
+    alias ConfigCat.Constants
+
+    require ConfigCat.Constants
+
+    def behaviour(data_source), do: data_source.override_behaviour
+
+    def overrides(%{filename: filename} = _data_source) do
+      with {:ok, contents} <- File.read(filename),
+           {:ok, data} <- Jason.decode(contents) do
+        {:ok, normalize(data)}
+      else
+        error ->
+          log_error(error, filename)
+          {:error, :not_found}
+      end
+    end
+
+    defp log_error({:error, %Jason.DecodeError{} = error}, filename) do
+      Logger.error("Could not decode json from file #{filename}. #{Exception.message(error)}")
+    end
+
+    defp log_error({:error, error}, filename) do
+      Logger.error(
+        "Could not read the content of the file #{filename}. #{:file.format_error(error)}"
+      )
+    end
+
+    defp normalize(%{"flags" => source} = _data) do
+      flags =
+        source
+        |> Enum.map(fn {key, value} -> {key, %{Constants.value() => value}} end)
+        |> Map.new()
+
+      %{Constants.feature_flags() => flags}
+    end
+
+    defp normalize(source), do: source
+  end
+end

--- a/lib/config_cat/local_map_data_source.ex
+++ b/lib/config_cat/local_map_data_source.ex
@@ -1,0 +1,32 @@
+defmodule ConfigCat.LocalMapDataSource do
+  @moduledoc """
+  Use flag overrides from a provided `Map`.
+
+  See `ConfigCat.OverrideDataSource` for more details.
+  """
+
+  alias ConfigCat.Constants
+  alias ConfigCat.OverrideDataSource
+
+  require ConfigCat.Constants
+  require Logger
+
+  defstruct [:override_behaviour, :settings]
+
+  def new(overrides, override_behaviour) do
+    flags =
+      overrides
+      |> Enum.map(fn {key, value} -> {key, %{Constants.value() => value}} end)
+      |> Map.new()
+
+    %__MODULE__{
+      override_behaviour: override_behaviour,
+      settings: %{Constants.feature_flags() => flags}
+    }
+  end
+
+  defimpl OverrideDataSource do
+    def behaviour(%{override_behaviour: behaviour}), do: behaviour
+    def overrides(%{settings: settings}), do: {:ok, settings}
+  end
+end

--- a/lib/config_cat/local_map_data_source.ex
+++ b/lib/config_cat/local_map_data_source.ex
@@ -5,14 +5,22 @@ defmodule ConfigCat.LocalMapDataSource do
   See `ConfigCat.OverrideDataSource` for more details.
   """
 
-  alias ConfigCat.Constants
-  alias ConfigCat.OverrideDataSource
+  alias ConfigCat.{Config, Constants, OverrideDataSource}
 
   require ConfigCat.Constants
   require Logger
 
   defstruct [:override_behaviour, :settings]
 
+  @type t :: %__MODULE__{
+          override_behaviour: OverrideDataSource.behaviour(),
+          settings: Config.t()
+        }
+
+  @doc """
+  Create a `ConfigCat.OverrideDataSource` from a map of flag/value pairs.
+  """
+  @spec new(map, OverrideDataSource.behaviour()) :: t
   def new(overrides, override_behaviour) do
     flags =
       overrides

--- a/lib/config_cat/null_data_source.ex
+++ b/lib/config_cat/null_data_source.ex
@@ -1,0 +1,22 @@
+defmodule ConfigCat.NullDataSource do
+  @moduledoc """
+  Don't provide any local flag overrides.
+
+  Used to avoid `is_nil` checks in the rest of the code.
+
+  See `ConfigCat.OverrideDataSource` for more details.
+  """
+
+  alias ConfigCat.OverrideDataSource
+
+  defstruct []
+
+  def new do
+    %__MODULE__{}
+  end
+
+  defimpl OverrideDataSource do
+    def behaviour(_data_source), do: :local_over_remote
+    def overrides(_data_source), do: {:ok, %{}}
+  end
+end

--- a/lib/config_cat/null_data_source.ex
+++ b/lib/config_cat/null_data_source.ex
@@ -11,6 +11,12 @@ defmodule ConfigCat.NullDataSource do
 
   defstruct []
 
+  @type t :: %__MODULE__{}
+
+  @doc """
+  Create a `ConfigCat.OverrideDataSource` that does nothing.
+  """
+  @spec new :: t
   def new do
     %__MODULE__{}
   end

--- a/lib/config_cat/override_data_source.ex
+++ b/lib/config_cat/override_data_source.ex
@@ -1,0 +1,48 @@
+defprotocol ConfigCat.OverrideDataSource do
+  @moduledoc """
+  Data source for local overrides of feature flags and settings.
+
+  With flag overrides you can overwrite the feature flags & settings downloaded
+  from the ConfigCat CDN with local values. Moreover, you can specify how the
+  overrides should apply over the downloaded values. See `t:behaviour`.
+  """
+
+  alias ConfigCat.Config
+
+  @typedoc """
+  Flag override behaviour.
+
+  The following 3 behaviours are supported:
+
+  - Local/Offline mode (`:local_only`): When evaluating values, the SDK will not
+    use feature flags & settings from the ConfigCat CDN, but it will use all
+    feature flags & settings that are loaded from local-override sources.
+
+  - Local over remote (`:local_over_remote`): When evaluating values, the SDK
+    will use all feature flags & settings that are downloaded from the ConfigCat
+    CDN, plus all feature flags & settings that are loaded from local-override
+    sources. If a feature flag or a setting is defined both in the downloaded
+    and the local-override source then the local-override version will take
+    precedence.
+
+  - Remote over local (`:remote_over_local): When evaluating values, the SDK
+    will use all feature flags & settings that are downloaded from the ConfigCat
+    CDN, plus all feature flags & settings that are loaded from local-override
+    sources. If a feature flag or a setting is defined both in the downloaded
+    and the local-override source then the downloaded version will take
+    precedence.
+  """
+  @type behaviour :: :local_only | :local_over_remote | :remote_over_local
+
+  @doc """
+  Return the selected flag override behaviour."
+  """
+  @spec behaviour(data_source :: t) :: behaviour
+  def behaviour(data_source)
+
+  @doc """
+  Return the local flag overrides from the data source.
+  """
+  @spec overrides(data_source :: t) :: {:ok, Config.t()} | {:error, term}
+  def overrides(data_source)
+end

--- a/lib/config_cat/override_data_source.ex
+++ b/lib/config_cat/override_data_source.ex
@@ -4,7 +4,7 @@ defprotocol ConfigCat.OverrideDataSource do
 
   With flag overrides you can overwrite the feature flags & settings downloaded
   from the ConfigCat CDN with local values. Moreover, you can specify how the
-  overrides should apply over the downloaded values. See `t:behaviour`.
+  overrides should apply over the downloaded values. See `t:behaviour/0`.
   """
 
   alias ConfigCat.Config
@@ -25,7 +25,7 @@ defprotocol ConfigCat.OverrideDataSource do
     and the local-override source then the local-override version will take
     precedence.
 
-  - Remote over local (`:remote_over_local): When evaluating values, the SDK
+  - Remote over local (`:remote_over_local`): When evaluating values, the SDK
     will use all feature flags & settings that are downloaded from the ConfigCat
     CDN, plus all feature flags & settings that are loaded from local-override
     sources. If a feature flag or a setting is defined both in the downloaded
@@ -35,7 +35,7 @@ defprotocol ConfigCat.OverrideDataSource do
   @type behaviour :: :local_only | :local_over_remote | :remote_over_local
 
   @doc """
-  Return the selected flag override behaviour."
+  Return the selected flag override behaviour.
   """
   @spec behaviour(data_source :: t) :: behaviour
   def behaviour(data_source)

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ConfigCat.MixProject do
       ],
       docs: [
         assets: "assets",
-        extras: ["README.md"],
+        extras: ["CONTRIBUTING.md", "README.md"],
         logo: "assets/logo.png",
         main: "readme"
       ],

--- a/test/config_cat/client_test.exs
+++ b/test/config_cat/client_test.exs
@@ -150,7 +150,7 @@ defmodule ConfigCat.ClientTest do
       name: name
     ]
 
-    {:ok, _pid} = Client.start_link(options)
+    {:ok, _pid} = start_supervised({Client, options})
 
     allow(MockCachePolicy, self(), name)
 

--- a/test/config_cat/client_test.exs
+++ b/test/config_cat/client_test.exs
@@ -3,7 +3,7 @@ defmodule ConfigCat.ClientTest do
 
   import Mox
 
-  alias ConfigCat.{Client, MockCachePolicy}
+  alias ConfigCat.{Client, MockCachePolicy, NullDataSource}
 
   @cache_policy_id :cache_policy_id
 
@@ -147,6 +147,7 @@ defmodule ConfigCat.ClientTest do
     options = [
       cache_policy: MockCachePolicy,
       cache_policy_id: @cache_policy_id,
+      flag_overrides: NullDataSource.new(),
       name: name
     ]
 

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -21,10 +21,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     name = UUID.uuid4() |> String.to_atom()
     default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
 
-    {:ok, _pid} =
-      default_options
-      |> Keyword.merge(options)
-      |> ConfigFetcher.start_link()
+    {:ok, _pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
 
     allow(MockAPI, self(), name)
 

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -24,10 +24,7 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
     name = UUID.uuid4() |> String.to_atom()
     default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
 
-    {:ok, _pid} =
-      default_options
-      |> Keyword.merge(options)
-      |> ConfigFetcher.start_link()
+    {:ok, _pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
 
     allow(MockAPI, self(), name)
 

--- a/test/config_cat/in_memory_cache_test.exs
+++ b/test/config_cat/in_memory_cache_test.exs
@@ -6,7 +6,7 @@ defmodule ConfigCat.InMemoryCacheTest do
   @cache_key "CACHE_KEY"
 
   setup do
-    {:ok, _pid} = Cache.start_link(cache_key: @cache_key)
+    {:ok, _pid} = start_supervised({Cache, [cache_key: @cache_key]})
 
     :ok
   end

--- a/test/fixtures/test.json
+++ b/test/fixtures/test.json
@@ -1,0 +1,19 @@
+{
+  "f": {
+    "disabledFeature": {
+      "v": false
+    },
+    "enabledFeature": {
+      "v": true
+    },
+    "intSetting": {
+      "v": 5
+    },
+    "doubleSetting": {
+      "v": 3.14
+    },
+    "stringSetting": {
+      "v": "test"
+    }
+  }
+}

--- a/test/fixtures/test_simple.json
+++ b/test/fixtures/test_simple.json
@@ -1,0 +1,9 @@
+{
+  "flags": {
+    "disabledFeature": false,
+    "enabledFeature": true,
+    "intSetting": 5,
+    "doubleSetting": 3.14,
+    "stringSetting": "test"
+  }
+}

--- a/test/flag_override_test.exs
+++ b/test/flag_override_test.exs
@@ -1,0 +1,188 @@
+defmodule ConfigCat.FlagOverrideTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias ConfigCat.{Client, LocalFileDataSource, LocalMapDataSource, MockCachePolicy}
+
+  @moduletag capture_log: true
+
+  @cache_policy_id :cache_policy_id
+
+  describe "local-only mode" do
+    test "uses flag values from a local file" do
+      filename = fixture_file("test.json")
+      overrides = LocalFileDataSource.new(filename, :local_only)
+
+      {:ok, client} = start_client(overrides)
+
+      assert Client.get_value(client, "enabledFeature", false) == true
+      assert Client.get_value(client, "disabledFeature", true) == false
+      assert Client.get_value(client, "intSetting", 0) == 5
+      assert Client.get_value(client, "doubleSetting", 0.0) == 3.14
+      assert Client.get_value(client, "stringSetting", "") == "test"
+    end
+
+    test "uses flag values from a simple-format local file" do
+      filename = fixture_file("test_simple.json")
+      overrides = LocalFileDataSource.new(filename, :local_only)
+
+      {:ok, client} = start_client(overrides)
+
+      assert Client.get_value(client, "enabledFeature", false) == true
+      assert Client.get_value(client, "disabledFeature", true) == false
+      assert Client.get_value(client, "intSetting", 0) == 5
+      assert Client.get_value(client, "doubleSetting", 0.0) == 3.14
+      assert Client.get_value(client, "stringSetting", "") == "test"
+    end
+
+    test "reloads file when modified" do
+      flags = %{"flags" => %{"enabledFeature" => false}}
+      filename = temporary_file("simple")
+      overrides = LocalFileDataSource.new(filename, :local_only)
+
+      {:ok, client} = start_client(overrides)
+
+      File.open(filename, [:write], fn file ->
+        IO.write(file, Jason.encode!(flags))
+      end)
+
+      assert Client.get_value(client, "enabledFeature", true) == false
+
+      # TODO: May need a sleep here once caching is implemented
+
+      modified_flags = put_in(flags, ["flags", "enabledFeature"], true)
+
+      File.open(filename, [:write], fn file ->
+        IO.write(file, Jason.encode!(modified_flags))
+      end)
+
+      assert Client.get_value(client, "enabledFeature", false) == true
+    end
+
+    test "uses default value if override file doesn't exist" do
+      filename = fixture_file("non_existent.json")
+      overrides = LocalFileDataSource.new(filename, :local_only)
+
+      {:ok, client} = start_client(overrides)
+
+      assert Client.get_value(client, "enabledFeature", false) == false
+    end
+
+    test "uses default value if override file is invalid" do
+      invalid_contents = ~s({"flags": {"enabledFeature": true}\n)
+      filename = temporary_file("invalid.json")
+      overrides = LocalFileDataSource.new(filename, :local_only)
+
+      {:ok, client} = start_client(overrides)
+
+      File.open(filename, [:write], fn file ->
+        IO.write(file, invalid_contents)
+      end)
+
+      assert Client.get_value(client, "enabledFeature", false) == false
+    end
+
+    test "uses flag values from a map" do
+      map = %{
+        "enabledFeature" => true,
+        "disabledFeature" => false,
+        "intSetting" => 5,
+        "doubleSetting" => 3.14,
+        "stringSetting" => "test"
+      }
+
+      overrides = LocalMapDataSource.new(map, :local_only)
+
+      {:ok, client} = start_client(overrides)
+
+      assert Client.get_value(client, "enabledFeature", false) == true
+      assert Client.get_value(client, "disabledFeature", true) == false
+      assert Client.get_value(client, "intSetting", 0) == 5
+      assert Client.get_value(client, "doubleSetting", 0.0) == 3.14
+      assert Client.get_value(client, "stringSetting", "") == "test"
+    end
+  end
+
+  defp fixture_file(name) do
+    __ENV__.file
+    |> Path.dirname()
+    |> Path.join("fixtures/" <> name)
+  end
+
+  defp temporary_file(name) do
+    dir = System.tmp_dir!()
+    filename = Path.join(dir, name)
+    on_exit(fn -> File.rm!(filename) end)
+
+    filename
+  end
+
+  defp start_client(flag_overrides) do
+    name = UUID.uuid4() |> String.to_atom()
+
+    options = [
+      cache_policy: MockCachePolicy,
+      cache_policy_id: @cache_policy_id,
+      flag_overrides: flag_overrides,
+      name: name
+    ]
+
+    {:ok, _pid} = start_supervised({Client, options})
+
+    allow(MockCachePolicy, self(), name)
+
+    {:ok, name}
+  end
+end
+
+# RSpec.describe 'Local test', type: :feature do
+#   script_dir = File.dirname(__FILE__)
+
+#   def stub_request()
+#     uri_template = Addressable::Template.new "https://{base_url}/{base_path}/{api_key}/{base_ext}"
+#     json = '{"f": {"fakeKey": {"v": false} } }'
+#     WebMock.stub_request(:get, uri_template)
+#         .with(
+#             body: "",
+#             headers: {
+#                 'Accept' => '*/*',
+#                 'Content-Type' => 'application/json',
+#                 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
+#             }
+#         )
+#         .to_return(status: 200, body: json, headers: {})
+#   end
+
+#   it "test local over remote" do
+#     stub_request()
+#     dictionary = {
+#         "fakeKey" => true,
+#         "nonexisting" => true
+#     }
+#     client = ConfigCat::ConfigCatClient.new("test",
+#                                             poll_interval_seconds: 0,
+#                                             max_init_wait_time_seconds: 0,
+#                                             flag_overrides: ConfigCat::LocalDictionaryDataSource.new(dictionary, ConfigCat::OverrideBehaviour::LOCAL_OVER_REMOTE))
+#     expect(client.get_value("fakeKey", false)).to eq true
+#     expect(client.get_value("nonexisting", false)).to eq true
+#     client.force_refresh()
+#     client.stop()
+#   end
+
+#   it "test remote over local" do
+#     stub_request()
+#     dictionary = {
+#         "fakeKey" => true,
+#         "nonexisting" => true
+#     }
+#     client = ConfigCat::ConfigCatClient.new("test",
+#                                             poll_interval_seconds: 0,
+#                                             max_init_wait_time_seconds: 0,
+#                                             flag_overrides: ConfigCat::LocalDictionaryDataSource.new(dictionary, ConfigCat::OverrideBehaviour::REMOTE_OVER_LOCAL))
+#     expect(client.get_value("fakeKey", true)).to eq false
+#     expect(client.get_value("nonexisting", false)).to eq true
+#     client.force_refresh()
+#     client.stop()
+#   end
+# end

--- a/test/flag_override_test.exs
+++ b/test/flag_override_test.exs
@@ -63,9 +63,12 @@ defmodule ConfigCat.FlagOverrideTest do
         IO.write(file, Jason.encode!(flags))
       end)
 
-      assert Client.get_value(client, "enabledFeature", true) == false
+      # Backdate file modification time so that it will be different when we
+      # rewrite it below. This avoids having to add a sleep to the test.
+      stat = File.stat!(filename, time: :posix)
+      File.touch!(filename, stat.mtime - 1)
 
-      # TODO: May need a sleep here once caching is implemented
+      assert Client.get_value(client, "enabledFeature", true) == false
 
       modified_flags = put_in(flags, ["flags", "enabledFeature"], true)
 

--- a/test/rollout_test.exs
+++ b/test/rollout_test.exs
@@ -165,10 +165,13 @@ defmodule ConfigCat.RolloutTest do
     name = UUID.uuid4() |> String.to_atom()
 
     with {:ok, _pid} <-
-           ConfigCat.start_link(
-             fetch_policy: CachePolicy.lazy(cache_expiry_seconds: 300),
-             name: name,
-             sdk_key: sdk_key
+           start_supervised(
+             {ConfigCat,
+              [
+                fetch_policy: CachePolicy.lazy(cache_expiry_seconds: 300),
+                name: name,
+                sdk_key: sdk_key
+              ]}
            ) do
       {:ok, name}
     else

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -26,13 +26,16 @@ defmodule ConfigCat.CachePolicyCase do
     {:ok, cache_key} = start_cache()
 
     {:ok, _pid} =
-      CachePolicy.start_link(
-        cache: InMemoryCache,
-        cache_key: cache_key,
-        cache_policy: policy,
-        fetcher: MockFetcher,
-        fetcher_id: @fetcher_id,
-        name: policy_id
+      start_supervised(
+        {CachePolicy,
+         [
+           cache: InMemoryCache,
+           cache_key: cache_key,
+           cache_policy: policy,
+           fetcher: MockFetcher,
+           fetcher_id: @fetcher_id,
+           name: policy_id
+         ]}
       )
 
     allow(MockFetcher, self(), policy_id)
@@ -42,7 +45,7 @@ defmodule ConfigCat.CachePolicyCase do
 
   defp start_cache do
     cache_key = UUID.uuid4()
-    {:ok, _pid} = InMemoryCache.start_link(cache_key: cache_key)
+    {:ok, _pid} = start_supervised({InMemoryCache, [cache_key: cache_key]})
 
     {:ok, cache_key}
   end


### PR DESCRIPTION
### Describe the purpose of your pull request

Implements the basic override data sources and hooks them into the application.

Uses a `NullDataSource` if not otherwise configured to avoid having to do to `is_nil` checks everywhere.

Also: refactored the tests to use `start_supervised`, which is a safer way to run GenServers in tests. I had to modify a couple of tests because `start_supervised` traps the exceptions that were being raised, so we need to assert against the trapped exception instead of catching it ourselves with `assert_raise`.

TODO:
- [x] Support :local_over_remote behaviour
- [x] Support :remote_over_local behaviour
- [x] Cache file contents to avoid reloading on every request
- [x] Don't start fetcher and cache-policy when `:local_only`
- [x] ~~Consider adding an `ApplicationConfigDataSource` that reads the flag map from the application's config file~~ Decided not to do this; a client application can choose to load a map from its config and use it with `LocalMapDataSource`.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
