### PR TITLE
move evaluation logs from info level to debug

### DIFF
--- a/lib/config_cat/rollout.ex
+++ b/lib/config_cat/rollout.ex
@@ -139,23 +139,23 @@ defmodule ConfigCat.Rollout do
 
   defp base_value(setting_descriptor, default_value) do
     result = Map.get(setting_descriptor, Constants.value(), default_value)
-    Logger.info("Returning #{result}")
+    Logger.debug("Returning #{result}")
 
     result
   end
 
   defp log_evaluating(key) do
-    Logger.info("Evaluating get_value('#{key}').")
+    Logger.debug("Evaluating get_value('#{key}').")
   end
 
   defp log_match(comparison_attribute, user_value, comparator, comparison_value, value) do
-    Logger.info(
+    Logger.debug(
       "Evaluating rule: [#{comparison_attribute}:#{user_value}] [#{Comparator.description(comparator)}] [#{comparison_value}] => match, returning: #{value}"
     )
   end
 
   defp log_no_match(comparison_attribute, user_value, comparator, comparison_value) do
-    Logger.info(
+    Logger.debug(
       "Evaluating rule: [#{comparison_attribute}:#{user_value}] [#{Comparator.description(comparator)}] [#{comparison_value}] => no match"
     )
   end
@@ -173,7 +173,7 @@ defmodule ConfigCat.Rollout do
   end
 
   defp log_valid_user(user) do
-    Logger.info("User object: #{inspect(user)}")
+    Logger.debug("User object: #{inspect(user)}")
   end
 
   defp log_nil_user(key) do

--- a/samples/multi/lib/multi/application.ex
+++ b/samples/multi/lib/multi/application.ex
@@ -10,9 +10,9 @@ defmodule Multi.Application do
 
   def start(_type, _args) do
 
-    # Info level logging helps to inspect the feature flag evaluation process.
+    # Debug level logging helps to inspect the feature flag evaluation process.
     # Use the :warning level to avoid too detailed logging in your application.
-    Logger.configure(level: :info)
+    Logger.configure(level: :debug)
 
     children = [
       Supervisor.child_spec({ConfigCat, [sdk_key: @sdk_key_1, name: :first]}, id: :config_cat_1),

--- a/samples/simple/lib/simple/application.ex
+++ b/samples/simple/lib/simple/application.ex
@@ -9,9 +9,9 @@ defmodule Simple.Application do
 
   def start(_type, _args) do
 
-    # Info level logging helps to inspect the feature flag evaluation process.
+    # Debug level logging helps to inspect the feature flag evaluation process.
     # Use the :warning level to avoid too detailed logging in your application.
-    Logger.configure(level: :info)
+    Logger.configure(level: :debug)
 
     children = [
       {ConfigCat, [sdk_key: @sdk_key]},


### PR DESCRIPTION
Fix: log feature flag evaluation on debug level

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
