### PR TITLE
Default user

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ env.OTP_VERSION }}
@@ -65,7 +65,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ env.ELIXIR_VERSION }}
         otp-version: ${{ env.OTP_VERSION }}

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir-version: ['1.11.x', '1.12.x', '1.13.x']
+        elixir-version: ['1.11.x', '1.12.x', '1.13.x', '1.14.x']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ env.OTP_VERSION }}
@@ -65,7 +65,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
+      uses: erlef/setup-elixir@v1
       with:
         elixir-version: ${{ env.ELIXIR_VERSION }}
         otp-version: ${{ env.OTP_VERSION }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: snyk/actions/setup@master
       - name: Set up Elixir
-        uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
+        uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -475,6 +475,40 @@ defmodule ConfigCat do
     Client.force_refresh(client_name(name))
   end
 
+  @doc """
+  Sets the default user.
+
+  Returns `:ok`.
+
+  ### Options
+
+  - `client`: If you are running multiple instances of `ConfigCat`, provide the
+    `client: :unique_name` option, specifying the name you configured for the
+    instance you want to access.
+  """
+  @spec set_default_user(User.t(), [api_option()]) :: :ok
+  def set_default_user(user, options \\ []) do
+    name = Keyword.get(options, :client, __MODULE__)
+    Client.set_default_user(client_name(name), user)
+  end
+
+  @doc """
+  Clears the default user.
+
+  Returns `:ok`.
+
+  ### Options
+
+  - `client`: If you are running multiple instances of `ConfigCat`, provide the
+    `client: :unique_name` option, specifying the name you configured for the
+    instance you want to access.
+  """
+  @spec clear_default_user([api_option()]) :: :ok
+  def clear_default_user(options \\ []) do
+    name = Keyword.get(options, :client, __MODULE__)
+    Client.clear_default_user(client_name(name))
+  end
+
   defp cache_policy_name(name), do: :"#{name}.CachePolicy"
   defp client_name(name), do: :"#{name}.Client"
   defp fetcher_name(name), do: :"#{name}.ConfigFetcher"

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -544,6 +544,7 @@ defmodule ConfigCat do
     |> Keyword.take([
       :cache_policy,
       :cache_policy_id,
+      :default_user,
       :flag_overrides,
       :name
     ])

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -82,11 +82,11 @@ defmodule ConfigCat do
     {ConfigCat, [sdk_key: "YOUR SDK KEY", cache_policy: ConfigCat.CachePolicy.manual()]}
     ```
 
-  - `connect_timeout`: **OPTIONAL** timeout for establishing a TCP or SSL connection,
+  - `connect_timeout_milliseconds`: **OPTIONAL** timeout for establishing a TCP or SSL connection,
     in milliseconds. Default is 8000.
 
     ```elixir
-    {ConfigCat, [sdk_key: "YOUR SDK KEY", connect_timeout: 8000]}
+    {ConfigCat, [sdk_key: "YOUR SDK KEY", connect_timeout_milliseconds: 8000]}
     ```
 
   - `data_governance`: **OPTIONAL** Describes the location of your feature flag
@@ -96,6 +96,13 @@ defmodule ConfigCat do
 
     ```elixir
     {ConfigCat, [sdk_key: "YOUR SDK KEY", data_governance: :eu_only]}
+    ```
+
+  - `default_user`: **OPTIONAL** user object that will be used as fallback when
+    there's no user parameter is passed to the getValue() method.
+
+    ```elixir
+    {ConfigCat, [sdk_key: "YOUR SDK KEY", default_user: User.new("test@test.com")]}
     ```
 
   - `flag_overrides`: **OPTIONAL** Specify a data source to use for [local flag
@@ -127,11 +134,11 @@ defmodule ConfigCat do
     ConfigCat.get_value("setting", "default", client: :unique_name)
     ```
 
-  - `read_timeout`: **OPTIONAL** timeout for receiving an HTTP response from
+  - `read_timeout_milliseconds`: **OPTIONAL** timeout for receiving an HTTP response from
     the socket, in milliseconds. Default is 5000.
 
     ```elixir
-    {ConfigCat, [sdk_key: "YOUR SDK KEY", read_timeout: 5000]}
+    {ConfigCat, [sdk_key: "YOUR SDK KEY", read_timeout_milliseconds: 5000]}
     ```
 
   ## Use the API
@@ -192,12 +199,13 @@ defmodule ConfigCat do
           {:base_url, String.t()}
           | {:cache, module()}
           | {:cache_policy, CachePolicy.t()}
-          | {:connect_timeout, non_neg_integer()}
+          | {:connect_timeout_milliseconds, non_neg_integer()}
           | {:data_governance, data_governance()}
+          | {:default_user, User.t()}
           | {:flag_overrides, OverrideDataSource.t()}
           | {:http_proxy, String.t()}
           | {:name, instance_id()}
-          | {:read_timeout, non_neg_integer()}
+          | {:read_timeout_milliseconds, non_neg_integer()}
           | {:sdk_key, String.t()}
 
   @type options :: [option()]
@@ -514,8 +522,8 @@ defmodule ConfigCat do
     |> Keyword.take([
       :base_url,
       :http_proxy,
-      :connect_timeout,
-      :read_timeout,
+      :connect_timeout_milliseconds,
+      :read_timeout_milliseconds,
       :data_governance,
       :mode,
       :name,

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -184,7 +184,7 @@ defmodule ConfigCat.Client do
   end
 
   defp evaluate(key, user, default_value, default_variation_id, state) do
-    user = if user != nil, do: user, else: state.default_user
+    user = if user != nil, do: user, else: Map.get(state, :default_user)
 
     with {:ok, config} <- cached_config(state) do
       {:ok, Rollout.evaluate(key, user, default_value, default_variation_id, config)}

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -149,10 +149,12 @@ defmodule ConfigCat.Client do
     {:reply, result, state}
   end
 
+  @impl GenServer
   def handle_call({:set_default_user, user}, _from, state) do
     {:reply, :ok, Map.put(state, :default_user, user)}
   end
 
+  @impl GenServer
   def handle_call(:clear_default_user, _from, state) do
     {:reply, :ok, Map.delete(state, :default_user)}
   end

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -71,6 +71,16 @@ defmodule ConfigCat.Client do
     GenServer.call(client, :force_refresh, Constants.fetch_timeout())
   end
 
+  @spec set_default_user(client(), User.t()) :: :ok
+  def set_default_user(client, user) do
+    GenServer.call(client, {:set_default_user, user}, Constants.fetch_timeout())
+  end
+
+  @spec clear_default_user(client()) :: :ok
+  def clear_default_user(client) do
+    GenServer.call(client, :clear_default_user, Constants.fetch_timeout())
+  end
+
   @impl GenServer
   def init(state) do
     {:ok, state}
@@ -137,6 +147,14 @@ defmodule ConfigCat.Client do
 
     result = policy.force_refresh(policy_id)
     {:reply, result, state}
+  end
+
+  def handle_call({:set_default_user, user}, _from, state) do
+    {:reply, :ok, Map.put(state, :default_user, user)}
+  end
+
+  def handle_call(:clear_default_user, _from, state) do
+    {:reply, :ok, Map.delete(state, :default_user)}
   end
 
   defp do_get_value(key, default_value, user, state) do

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -185,6 +185,7 @@ defmodule ConfigCat.Client do
 
   defp evaluate(key, user, default_value, default_variation_id, state) do
     user = if user != nil, do: user, else: state.default_user
+
     with {:ok, config} <- cached_config(state) do
       {:ok, Rollout.evaluate(key, user, default_value, default_variation_id, config)}
     else

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -184,6 +184,7 @@ defmodule ConfigCat.Client do
   end
 
   defp evaluate(key, user, default_value, default_variation_id, state) do
+    user = if user != nil, do: user, else: state.default_user
     with {:ok, config} <- cached_config(state) do
       {:ok, Rollout.evaluate(key, user, default_value, default_variation_id, config)}
     else

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -60,7 +60,12 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp default_options,
-    do: [api: ConfigCat.API, data_governance: :global, connect_timeout_milliseconds: 8000, read_timeout_milliseconds: 5000]
+    do: [
+      api: ConfigCat.API,
+      data_governance: :global,
+      connect_timeout_milliseconds: 8000,
+      read_timeout_milliseconds: 5000
+    ]
 
   defp choose_base_url(options) do
     case Keyword.get(options, :base_url) do
@@ -136,7 +141,8 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp http_options(state) do
-    options = Map.take(state, [:http_proxy, :connect_timeout_milliseconds, :read_timeout_milliseconds])
+    options =
+      Map.take(state, [:http_proxy, :connect_timeout_milliseconds, :read_timeout_milliseconds])
 
     Enum.map(options, fn
       {:http_proxy, value} -> {:proxy, value}

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -36,8 +36,8 @@ defmodule ConfigCat.CacheControlConfigFetcher do
           {:base_url, String.t()}
           | {:data_governance, ConfigCat.data_governance()}
           | {:http_proxy, String.t()}
-          | {:connect_timeout, non_neg_integer()}
-          | {:read_timeout, non_neg_integer()}
+          | {:connect_timeout_milliseconds, non_neg_integer()}
+          | {:read_timeout_milliseconds, non_neg_integer()}
           | {:mode, String.t()}
           | {:name, ConfigFetcher.id()}
           | {:sdk_key, String.t()}
@@ -60,7 +60,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp default_options,
-    do: [api: ConfigCat.API, data_governance: :global, connect_timeout: 8000, read_timeout: 5000]
+    do: [api: ConfigCat.API, data_governance: :global, connect_timeout_milliseconds: 8000, read_timeout_milliseconds: 5000]
 
   defp choose_base_url(options) do
     case Keyword.get(options, :base_url) do
@@ -136,12 +136,12 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp http_options(state) do
-    options = Map.take(state, [:http_proxy, :connect_timeout, :read_timeout])
+    options = Map.take(state, [:http_proxy, :connect_timeout_milliseconds, :read_timeout_milliseconds])
 
     Enum.map(options, fn
       {:http_proxy, value} -> {:proxy, value}
-      {:connect_timeout, value} -> {:timeout, value}
-      {:read_timeout, value} -> {:recv_timeout, value}
+      {:connect_timeout_milliseconds, value} -> {:timeout, value}
+      {:read_timeout_milliseconds, value} -> {:recv_timeout, value}
     end)
   end
 
@@ -228,7 +228,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
     case error do
       {:error, %HTTPoison.Error{reason: :checkout_timeout}} ->
         Logger.error(
-          "Request timed out. Timeout values: [connect: #{state.connect_timeout}ms, read: #{state.read_timeout}ms]"
+          "Request timed out. Timeout values: [connect: #{state.connect_timeout_milliseconds}ms, read: #{state.read_timeout_milliseconds}ms]"
         )
 
       _error ->

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -160,7 +160,10 @@ defmodule ConfigCat.ConfigFetcherTest do
     read_timeout = 2000
 
     {:ok, fetcher} =
-      start_fetcher(@fetcher_options, connect_timeout_milliseconds: connect_timeout, read_timeout_milliseconds: read_timeout)
+      start_fetcher(@fetcher_options,
+        connect_timeout_milliseconds: connect_timeout,
+        read_timeout_milliseconds: read_timeout
+      )
 
     response = %Response{status_code: 200, body: @config}
 

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -160,7 +160,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     read_timeout = 2000
 
     {:ok, fetcher} =
-      start_fetcher(@fetcher_options, connect_timeout: connect_timeout, read_timeout: read_timeout)
+      start_fetcher(@fetcher_options, connect_timeout_milliseconds: connect_timeout, read_timeout_milliseconds: read_timeout)
 
     response = %Response{status_code: 200, body: @config}
 

--- a/test/config_cat/default_user_test.exs
+++ b/test/config_cat/default_user_test.exs
@@ -31,7 +31,7 @@ defmodule ConfigCat.DefaultUserTest do
     {:ok, config: config}
   end
 
-  describe "when the default user is defined" do
+  describe "when the default user is defined in the options" do
     setup do
       {:ok, client} = start_client(User.new("test@test1.com"))
       {:ok, client: client}
@@ -77,7 +77,7 @@ defmodule ConfigCat.DefaultUserTest do
     end
   end
 
-  describe "when the default user is not defined" do
+  describe "when the default user is not defined in the options" do
     setup do
       {:ok, client} = start_client()
       {:ok, client: client}

--- a/test/config_cat/default_user_test.exs
+++ b/test/config_cat/default_user_test.exs
@@ -1,0 +1,133 @@
+defmodule ConfigCat.DefaultUserTest do
+  use ExUnit.Case, async: true
+
+  import Mox
+
+  alias ConfigCat.{Client, MockCachePolicy, NullDataSource, User}
+
+  @moduletag capture_log: true
+
+  @cache_policy_id :cache_policy_id
+
+  setup do
+    config = Jason.decode!(~s(
+      {
+        "p": {"u": "https://cdn-global.configcat.com", "r": 0},
+        "f": {
+          "testBoolKey": {"v": true,"t": 0, "p": [],"r": []},
+          "testStringKey": {
+            "v": "testValue", "i": "id", "t": 1, "p": [], "r": [
+              {"i":"id1","v":"fake1","a":"Identifier","t":2,"c":"@test1.com"},
+              {"i":"id2","v":"fake2","a":"Identifier","t":2,"c":"@test2.com"}
+            ]
+          }
+        }
+      }
+    ))
+
+    MockCachePolicy
+    |> stub(:get, fn @cache_policy_id -> {:ok, config} end)
+
+    {:ok, config: config}
+  end
+
+  describe "when the default user is defined" do
+    setup do
+      {:ok, client} = start_client(User.new("test@test1.com"))
+      {:ok, client: client}
+    end
+
+    test "get_value/4 uses the default user if no user is passed", %{client: client} do
+      assert Client.get_value(client, "testStringKey", "") == "fake1"
+    end
+
+    test "get_value/4 uses the passed user", %{client: client} do
+      user = User.new("test@test2.com")
+      assert Client.get_value(client, "testStringKey", "", user) == "fake2"
+    end
+
+    test "get_all_values/1 uses the default user if no user is passed", %{client: client} do
+      expected =
+        %{
+          "testBoolKey" => true,
+          "testStringKey" => "fake1"
+        }
+        |> Enum.sort()
+
+      actual = client |> Client.get_all_values() |> Enum.sort()
+      assert actual == expected
+    end
+
+    test "get_all_values/1 uses the passed user", %{client: client} do
+      expected =
+        %{
+          "testBoolKey" => true,
+          "testStringKey" => "fake2"
+        }
+        |> Enum.sort()
+
+      user = User.new("test@test2.com")
+      actual = client |> Client.get_all_values(user) |> Enum.sort()
+      assert actual == expected
+    end
+  end
+
+  describe "when the default user is not defined" do
+    setup do
+      {:ok, client} = start_client()
+      {:ok, client: client}
+    end
+
+    test "get_value/4 uses the undefined user case if no user is passed", %{client: client} do
+      assert Client.get_value(client, "testStringKey", "") == "testValue"
+    end
+
+    test "get_value/4 uses the passed user", %{client: client} do
+      user = User.new("test@test2.com")
+      assert Client.get_value(client, "testStringKey", "", user) == "fake2"
+    end
+
+    test "get_all_values/1 uses the undefined user case if no user is passed", %{client: client} do
+      expected =
+        %{
+          "testBoolKey" => true,
+          "testStringKey" => "testValue"
+        }
+        |> Enum.sort()
+
+      actual = client |> Client.get_all_values() |> Enum.sort()
+      assert actual == expected
+    end
+
+    test "get_all_values/1 uses the passed user", %{client: client} do
+      expected =
+        %{
+          "testBoolKey" => true,
+          "testStringKey" => "fake2"
+        }
+        |> Enum.sort()
+
+      user = User.new("test@test2.com")
+      actual = client |> Client.get_all_values(user) |> Enum.sort()
+      assert actual == expected
+    end
+  end
+
+  defp start_client(default_user \\ nil) do
+    name = UUID.uuid4() |> String.to_atom()
+
+    options = [
+      cache_policy: MockCachePolicy,
+      cache_policy_id: @cache_policy_id,
+      default_user: default_user,
+      flag_overrides: NullDataSource.new(),
+      name: name
+    ]
+
+    {:ok, _pid} = start_supervised({Client, options})
+
+    allow(MockCachePolicy, self(), name)
+
+    {:ok, name}
+  end
+end

--- a/test/config_cat/default_user_test.exs
+++ b/test/config_cat/default_user_test.exs
@@ -46,6 +46,11 @@ defmodule ConfigCat.DefaultUserTest do
       assert Client.get_value(client, "testStringKey", "", user) == "fake2"
     end
 
+    test "get_value/4 uses the undefined user case if default user is cleared", %{client: client} do
+      Client.clear_default_user(client)
+      assert Client.get_value(client, "testStringKey", "") == "testValue"
+    end
+
     test "get_all_values/1 uses the default user if no user is passed", %{client: client} do
       expected =
         %{
@@ -85,6 +90,11 @@ defmodule ConfigCat.DefaultUserTest do
     test "get_value/4 uses the passed user", %{client: client} do
       user = User.new("test@test2.com")
       assert Client.get_value(client, "testStringKey", "", user) == "fake2"
+    end
+
+    test "get_value/4 uses the default user if no user is passed", %{client: client} do
+      Client.set_default_user(client, User.new("test@test1.com"))
+      assert Client.get_value(client, "testStringKey", "") == "fake1"
     end
 
     test "get_all_values/1 uses the undefined user case if no user is passed", %{client: client} do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -79,7 +79,8 @@ defmodule ConfigCat.IntegrationTest do
 
   @tag capture_log: true
   test "handles timeout" do
-    {:ok, client} = start_config_cat(@sdk_key, connect_timeout_milliseconds: 0, read_timeout_milliseconds: 0)
+    {:ok, client} =
+      start_config_cat(@sdk_key, connect_timeout_milliseconds: 0, read_timeout_milliseconds: 0)
 
     assert ConfigCat.get_value("keySampleText", "default value", client: client) ==
              "default value"

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -59,7 +59,7 @@ defmodule ConfigCat.IntegrationTest do
     {:ok, client} = start_config_cat("invalid_sdk_key")
 
     {:error, response} = ConfigCat.force_refresh(client: client)
-    assert response.status_code == 404
+    assert response.status_code == 403
   end
 
   @tag capture_log: true
@@ -79,7 +79,7 @@ defmodule ConfigCat.IntegrationTest do
 
   @tag capture_log: true
   test "handles timeout" do
-    {:ok, client} = start_config_cat(@sdk_key, connect_timeout: 0, read_timeout: 0)
+    {:ok, client} = start_config_cat(@sdk_key, connect_timeout_milliseconds: 0, read_timeout_milliseconds: 0)
 
     assert ConfigCat.get_value("keySampleText", "default value", client: client) ==
              "default value"


### PR DESCRIPTION
### Describe the purpose of your pull request

- In the client options, you can set a default user object used when there's no user passed to `get_value()` / `get_all_values()` / `get_variation_id()` / `get_all_variation_ids()` methods.
- `set_default_user(user)` / `clear_default_user()` methods to set / remove a default user object used when there's no user passed to `get_value()` / `get_all_values()` / `get_variation_id()` / `get_all_variation_ids()` methods.
- Fix broken test
- Add elixir 1.14.x version to the auto tests
- In the client options, the following params changed:
  - `connect_timeout` to `connect_timeout_milliseconds` (to indicate the unit of measure).
  - `read_timeout` to `read_timeout_milliseconds` (to indicate the unit of measure).

### Related issues (only if applicable)

https://trello.com/c/XneffR1g/270-default-user-template-2022-09-05-elixir

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
