### PR TITLE
⬆️ Upgrade to newer Elixir/Erlang versions

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -12,8 +12,8 @@ on:
   workflow_dispatch:
 
 env:
-  ELIXIR_VERSION: '1.13.x'
-  OTP_VERSION: '24.x'
+  ELIXIR_VERSION: '1.14.x'
+  OTP_VERSION: '25.x'
 
 jobs:
   test:

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   ELIXIR_VERSION: '1.14.x'
-  OTP_VERSION: '25.x'
+  OTP_VERSION: '24.x'
 
 jobs:
   test:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.4-otp-24
-erlang 24.3.4
+elixir 1.14.4-otp-25
+erlang 25.3.2

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule ConfigCat.MixProject do
       {:elixir_uuid, "~> 1.2"},
       {:httpoison, "~> 1.7"},
       {:jason, "~> 1.2"},
-      {:dialyxir, "~> 1.0", only: :dev, runtime: false},
+      {:dialyxir, "~> 1.3", only: :dev, runtime: false},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:excoveralls, "~> 0.14.5", only: :test},
       {:mix_test_interactive, "~> 1.2", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
-  "dialyxir": {:hex, :dialyxir, "1.0.0", "6a1fa629f7881a9f5aaf3a78f094b2a51a0357c843871b8bc98824e7342d00a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "aeb06588145fac14ca08d8061a142d52753dbc2cf7f0d00fc1013f53f8654654"},
+  "dialyxir": {:hex, :dialyxir, "1.3.0", "fd1672f0922b7648ff9ce7b1b26fcf0ef56dda964a459892ad15f6b4410b5284", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "00b2a4bcd6aa8db9dcb0b38c1225b7277dca9bc370b6438715667071a304696f"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},


### PR DESCRIPTION
Erlang/OTP 26 was just released this week, so only moving to the latest 25.x version for now.

### Describe the purpose of your pull request

- Use the latest released version of Elixir and the latest released version of Erlang 25.x for local development
- Continue using Erlang 24.x in CI as that's the latest version supported by Elixir 1.11 - 1.13

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
