### PR TITLE
🏗️ Simplify architecture (part 1)

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -170,7 +170,6 @@ defmodule ConfigCat do
   """
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.Client
   alias ConfigCat.Config
   alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -243,7 +243,7 @@ defmodule ConfigCat do
   def get_all_keys(options \\ []) do
     options
     |> client()
-    |> Client.get_all_keys()
+    |> GenServer.call(:get_all_keys, Constants.fetch_timeout())
   end
 
   @doc "See `get_value/4`."
@@ -276,7 +276,7 @@ defmodule ConfigCat do
   def get_value(key, default_value, user, options) do
     options
     |> client()
-    |> Client.get_value(key, default_value, user)
+    |> GenServer.call({:get_value, key, default_value, user}, Constants.fetch_timeout())
   end
 
   @doc "See `get_variation_id/4`."
@@ -310,7 +310,10 @@ defmodule ConfigCat do
   def get_variation_id(key, default_variation_id, user, options) do
     options
     |> client()
-    |> Client.get_variation_id(key, default_variation_id, user)
+    |> GenServer.call(
+      {:get_variation_id, key, default_variation_id, user},
+      Constants.fetch_timeout()
+    )
   end
 
   @doc "See `get_all_variation_ids/2`."
@@ -342,7 +345,7 @@ defmodule ConfigCat do
   def get_all_variation_ids(user, options) do
     options
     |> client()
-    |> Client.get_all_variation_ids(user)
+    |> GenServer.call({:get_all_variation_ids, user}, Constants.fetch_timeout())
   end
 
   @doc """
@@ -361,7 +364,7 @@ defmodule ConfigCat do
   def get_key_and_value(variation_id, options \\ []) do
     options
     |> client()
-    |> Client.get_key_and_value(variation_id)
+    |> GenServer.call({:get_key_and_value, variation_id}, Constants.fetch_timeout())
   end
 
   @doc """
@@ -383,7 +386,7 @@ defmodule ConfigCat do
   def get_all_values(user, options \\ []) do
     options
     |> client()
-    |> Client.get_all_values(user)
+    |> GenServer.call({:get_all_values, user}, Constants.fetch_timeout())
   end
 
   @doc """
@@ -408,7 +411,7 @@ defmodule ConfigCat do
   def force_refresh(options \\ []) do
     options
     |> client()
-    |> Client.force_refresh()
+    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @doc """
@@ -426,7 +429,7 @@ defmodule ConfigCat do
   def set_default_user(user, options \\ []) do
     options
     |> client()
-    |> Client.set_default_user(user)
+    |> GenServer.call({:set_default_user, user}, Constants.fetch_timeout())
   end
 
   @doc """
@@ -444,7 +447,7 @@ defmodule ConfigCat do
   def clear_default_user(options \\ []) do
     options
     |> client()
-    |> Client.clear_default_user()
+    |> GenServer.call(:clear_default_user, Constants.fetch_timeout())
   end
 
   @doc """
@@ -462,7 +465,7 @@ defmodule ConfigCat do
   def set_online(options \\ []) do
     options
     |> client()
-    |> Client.set_online()
+    |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @doc """
@@ -480,7 +483,7 @@ defmodule ConfigCat do
   def set_offline(options \\ []) do
     options
     |> client()
-    |> Client.set_offline()
+    |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @doc """
@@ -496,7 +499,7 @@ defmodule ConfigCat do
   def is_offline(options \\ []) do
     options
     |> client()
-    |> Client.is_offline()
+    |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   defp client(options) do

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -241,8 +241,9 @@ defmodule ConfigCat do
   """
   @spec get_all_keys([api_option()]) :: [key()]
   def get_all_keys(options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.get_all_keys(client_name(name))
+    options
+    |> client()
+    |> Client.get_all_keys()
   end
 
   @doc "See `get_value/4`."
@@ -273,8 +274,9 @@ defmodule ConfigCat do
   """
   @spec get_value(key(), value(), User.t() | nil, [api_option()]) :: value()
   def get_value(key, default_value, user, options) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.get_value(client_name(name), key, default_value, user)
+    options
+    |> client()
+    |> Client.get_value(key, default_value, user)
   end
 
   @doc "See `get_variation_id/4`."
@@ -306,8 +308,9 @@ defmodule ConfigCat do
   """
   @spec get_variation_id(key(), variation_id(), User.t() | nil, [api_option()]) :: variation_id()
   def get_variation_id(key, default_variation_id, user, options) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.get_variation_id(client_name(name), key, default_variation_id, user)
+    options
+    |> client()
+    |> Client.get_variation_id(key, default_variation_id, user)
   end
 
   @doc "See `get_all_variation_ids/2`."
@@ -337,8 +340,9 @@ defmodule ConfigCat do
   """
   @spec get_all_variation_ids(User.t() | nil, [api_option()]) :: [variation_id()]
   def get_all_variation_ids(user, options) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.get_all_variation_ids(client_name(name), user)
+    options
+    |> client()
+    |> Client.get_all_variation_ids(user)
   end
 
   @doc """
@@ -355,8 +359,9 @@ defmodule ConfigCat do
   """
   @spec get_key_and_value(variation_id(), [api_option()]) :: {key(), value()} | nil
   def get_key_and_value(variation_id, options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.get_key_and_value(client_name(name), variation_id)
+    options
+    |> client()
+    |> Client.get_key_and_value(variation_id)
   end
 
   @doc """
@@ -376,8 +381,9 @@ defmodule ConfigCat do
   """
   @spec get_all_values(User.t() | nil, [api_option()]) :: %{key() => value()}
   def get_all_values(user, options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.get_all_values(client_name(name), user)
+    options
+    |> client()
+    |> Client.get_all_values(user)
   end
 
   @doc """
@@ -400,8 +406,9 @@ defmodule ConfigCat do
   """
   @spec force_refresh([api_option()]) :: refresh_result()
   def force_refresh(options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.force_refresh(client_name(name))
+    options
+    |> client()
+    |> Client.force_refresh()
   end
 
   @doc """
@@ -417,8 +424,9 @@ defmodule ConfigCat do
   """
   @spec set_default_user(User.t(), [api_option()]) :: :ok
   def set_default_user(user, options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.set_default_user(client_name(name), user)
+    options
+    |> client()
+    |> Client.set_default_user(user)
   end
 
   @doc """
@@ -434,8 +442,9 @@ defmodule ConfigCat do
   """
   @spec clear_default_user([api_option()]) :: :ok
   def clear_default_user(options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.clear_default_user(client_name(name))
+    options
+    |> client()
+    |> Client.clear_default_user()
   end
 
   @doc """
@@ -451,8 +460,9 @@ defmodule ConfigCat do
   """
   @spec set_online([api_option()]) :: :ok
   def set_online(options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.set_online(client_name(name))
+    options
+    |> client()
+    |> Client.set_online()
   end
 
   @doc """
@@ -468,8 +478,9 @@ defmodule ConfigCat do
   """
   @spec set_offline([api_option()]) :: :ok
   def set_offline(options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.set_offline(client_name(name))
+    options
+    |> client()
+    |> Client.set_offline()
   end
 
   @doc """
@@ -483,9 +494,14 @@ defmodule ConfigCat do
   """
   @spec is_offline([api_option()]) :: boolean()
   def is_offline(options \\ []) do
-    name = Keyword.get(options, :client, __MODULE__)
-    Client.is_offline(client_name(name))
+    options
+    |> client()
+    |> Client.is_offline()
   end
 
-  defp client_name(name), do: ConfigCat.Supervisor.client_name(name)
+  defp client(options) do
+    options
+    |> Keyword.get(:client, __MODULE__)
+    |> ConfigCat.Supervisor.client_name()
+  end
 end

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -559,7 +559,7 @@ defmodule ConfigCat do
     `client: :unique_name` option, specifying the name you configured for the
     instance you want to access.
   """
-  @spec is_offline([api_option()]) :: :bollean
+  @spec is_offline([api_option()]) :: boolean()
   def is_offline(options \\ []) do
     name = Keyword.get(options, :client, __MODULE__)
     Client.is_offline(client_name(name))

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -169,15 +169,10 @@ defmodule ConfigCat do
   ```
   """
 
-  use Supervisor
-
-  alias ConfigCat.CacheControlConfigFetcher
   alias ConfigCat.CachePolicy
   alias ConfigCat.Client
   alias ConfigCat.Config
   alias ConfigCat.Constants
-  alias ConfigCat.InMemoryCache
-  alias ConfigCat.NullDataSource
   alias ConfigCat.OverrideDataSource
   alias ConfigCat.User
 
@@ -225,88 +220,15 @@ defmodule ConfigCat do
   @typedoc "The name of a variation being tested."
   @type variation_id :: Config.variation_id()
 
-  @default_cache InMemoryCache
-
   @doc """
-  Starts an instance of `ConfigCat`.
+  Builds a child specification to use in a Supervisor.
 
   Normally not called directly by your code. Instead, it will be
   called by your application's Supervisor once you add `ConfigCat`
   to its supervision tree.
   """
-  @spec start_link(options()) :: Supervisor.on_start()
-  def start_link(options) when is_list(options) do
-    sdk_key = options[:sdk_key]
-    validate_sdk_key(sdk_key)
-
-    options =
-      default_options()
-      |> Keyword.merge(options)
-      |> generate_cache_key(sdk_key)
-
-    name = Keyword.fetch!(options, :name)
-    Supervisor.start_link(__MODULE__, options, name: name)
-  end
-
-  defp validate_sdk_key(nil), do: raise(ArgumentError, "SDK Key is required")
-  defp validate_sdk_key(""), do: raise(ArgumentError, "SDK Key is required")
-  defp validate_sdk_key(sdk_key) when is_binary(sdk_key), do: :ok
-
-  defp default_options,
-    do: [
-      cache: @default_cache,
-      cache_policy: CachePolicy.auto(),
-      flag_overrides: NullDataSource.new(),
-      name: __MODULE__,
-      offline: false
-    ]
-
-  @impl Supervisor
-  def init(options) do
-    fetcher_options = fetcher_options(options)
-
-    policy_options =
-      options
-      |> Keyword.put(:fetcher_id, fetcher_options[:name])
-      |> cache_policy_options()
-
-    client_options =
-      options
-      |> Keyword.put(:cache_policy_id, policy_options[:name])
-      |> client_options()
-
-    override_behaviour = OverrideDataSource.behaviour(options[:flag_overrides])
-
-    children =
-      [
-        default_cache(options),
-        config_fetcher(fetcher_options, override_behaviour),
-        cache_policy(policy_options, override_behaviour),
-        {Client, client_options}
-      ]
-      |> Enum.reject(&is_nil/1)
-
-    Supervisor.init(children, strategy: :one_for_one)
-  end
-
-  defp default_cache(options) do
-    case Keyword.get(options, :cache) do
-      @default_cache -> {@default_cache, cache_options(options)}
-      _ -> nil
-    end
-  end
-
-  defp config_fetcher(_options, :local_only), do: nil
-
-  defp config_fetcher(options, _override_behaviour) do
-    {CacheControlConfigFetcher, options}
-  end
-
-  defp cache_policy(_options, :local_only), do: nil
-
-  defp cache_policy(options, _override_behaviour) do
-    {CachePolicy, options}
-  end
+  @spec child_spec(options()) :: Supervisor.child_spec()
+  defdelegate child_spec(options), to: ConfigCat.Supervisor
 
   @doc """
   Queries all settings keys in your configuration.
@@ -565,60 +487,5 @@ defmodule ConfigCat do
     Client.is_offline(client_name(name))
   end
 
-  defp cache_policy_name(name), do: :"#{name}.CachePolicy"
-  defp client_name(name), do: :"#{name}.Client"
-  defp fetcher_name(name), do: :"#{name}.ConfigFetcher"
-
-  defp generate_cache_key(options, sdk_key) do
-    prefix =
-      case Keyword.get(options, :cache) do
-        @default_cache -> options[:name]
-        _ -> "elixir_"
-      end
-
-    cache_key =
-      :crypto.hash(:sha, "#{prefix}_#{ConfigCat.Constants.config_filename()}_#{sdk_key}")
-      |> Base.encode16()
-
-    Keyword.put(options, :cache_key, cache_key)
-  end
-
-  defp cache_options(options) do
-    Keyword.take(options, [:cache_key])
-  end
-
-  defp cache_policy_options(options) do
-    options
-    |> Keyword.update!(:name, &cache_policy_name/1)
-    |> Keyword.take([:cache, :cache_key, :cache_policy, :fetcher_id, :name, :offline])
-  end
-
-  defp client_options(options) do
-    options
-    |> Keyword.update!(:name, &client_name/1)
-    |> Keyword.update!(:cache_policy, &CachePolicy.policy_name/1)
-    |> Keyword.take([
-      :cache_policy,
-      :cache_policy_id,
-      :default_user,
-      :flag_overrides,
-      :name
-    ])
-  end
-
-  defp fetcher_options(options) do
-    options
-    |> Keyword.update!(:name, &fetcher_name/1)
-    |> Keyword.put(:mode, options[:cache_policy].mode)
-    |> Keyword.take([
-      :base_url,
-      :http_proxy,
-      :connect_timeout_milliseconds,
-      :read_timeout_milliseconds,
-      :data_governance,
-      :mode,
-      :name,
-      :sdk_key
-    ])
-  end
+  defp client_name(name), do: ConfigCat.Supervisor.client_name(name)
 end

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -8,7 +8,7 @@ defmodule ConfigCat.CachePolicy.Behaviour do
   @type refresh_result :: CachePolicy.refresh_result()
 
   @callback get(id()) :: {:ok, Config.t()} | {:error, :not_found}
-  @callback is_offline(id()) :: :boolean
+  @callback is_offline(id()) :: boolean()
   @callback set_offline(id()) :: :ok
   @callback set_online(id()) :: :ok
   @callback force_refresh(id()) :: refresh_result()

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -4,11 +4,9 @@ defmodule ConfigCat.Client do
   use GenServer
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.Config
   alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource
   alias ConfigCat.Rollout
-  alias ConfigCat.User
 
   require Constants
   require Logger
@@ -27,71 +25,6 @@ defmodule ConfigCat.Client do
     with {name, options} <- Keyword.pop!(options, :name) do
       GenServer.start_link(__MODULE__, Map.new(options), name: name)
     end
-  end
-
-  @spec get_all_keys(client()) :: [Config.key()]
-  def get_all_keys(client) do
-    GenServer.call(client, :get_all_keys, Constants.fetch_timeout())
-  end
-
-  @spec get_value(client(), Config.key(), Config.value(), User.t() | nil) :: Config.value()
-  def get_value(client, key, default_value, user \\ nil) do
-    GenServer.call(client, {:get_value, key, default_value, user}, Constants.fetch_timeout())
-  end
-
-  @spec get_variation_id(client(), Config.key(), Config.variation_id(), User.t() | nil) ::
-          Config.variation_id()
-  def get_variation_id(client, key, default_variation_id, user \\ nil) do
-    GenServer.call(
-      client,
-      {:get_variation_id, key, default_variation_id, user},
-      Constants.fetch_timeout()
-    )
-  end
-
-  @spec get_all_variation_ids(client(), User.t() | nil) :: [Config.variation_id()]
-  def get_all_variation_ids(client, user \\ nil) do
-    GenServer.call(client, {:get_all_variation_ids, user}, Constants.fetch_timeout())
-  end
-
-  @spec get_key_and_value(client(), Config.variation_id()) :: {Config.key(), Config.value()} | nil
-  def get_key_and_value(client, variation_id) do
-    GenServer.call(client, {:get_key_and_value, variation_id}, Constants.fetch_timeout())
-  end
-
-  @spec get_all_values(client(), User.t() | nil) :: %{Config.key() => Config.value()}
-  def get_all_values(client, user \\ nil) do
-    GenServer.call(client, {:get_all_values, user}, Constants.fetch_timeout())
-  end
-
-  @spec force_refresh(client()) :: refresh_result()
-  def force_refresh(client) do
-    GenServer.call(client, :force_refresh, Constants.fetch_timeout())
-  end
-
-  @spec set_default_user(client(), User.t()) :: :ok
-  def set_default_user(client, user) do
-    GenServer.call(client, {:set_default_user, user}, Constants.fetch_timeout())
-  end
-
-  @spec clear_default_user(client()) :: :ok
-  def clear_default_user(client) do
-    GenServer.call(client, :clear_default_user, Constants.fetch_timeout())
-  end
-
-  @spec set_online(client()) :: :ok
-  def set_online(client) do
-    GenServer.call(client, :set_online, Constants.fetch_timeout())
-  end
-
-  @spec set_offline(client()) :: :ok
-  def set_offline(client) do
-    GenServer.call(client, :set_offline, Constants.fetch_timeout())
-  end
-
-  @spec is_offline(client()) :: boolean()
-  def is_offline(client) do
-    GenServer.call(client, :is_offline, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -89,7 +89,7 @@ defmodule ConfigCat.Client do
     GenServer.call(client, :set_offline, Constants.fetch_timeout())
   end
 
-  @spec is_offline(client()) :: :bollean
+  @spec is_offline(client()) :: boolean()
   def is_offline(client) do
     GenServer.call(client, :is_offline, Constants.fetch_timeout())
   end

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -1,0 +1,150 @@
+defmodule ConfigCat.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias ConfigCat.CacheControlConfigFetcher
+  alias ConfigCat.CachePolicy
+  alias ConfigCat.Client
+  alias ConfigCat.Constants
+  alias ConfigCat.InMemoryCache
+  alias ConfigCat.NullDataSource
+  alias ConfigCat.OverrideDataSource
+
+  require Constants
+
+  @default_cache InMemoryCache
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(options) when is_list(options) do
+    sdk_key = options[:sdk_key]
+    validate_sdk_key(sdk_key)
+
+    options =
+      default_options()
+      |> Keyword.merge(options)
+      |> generate_cache_key(sdk_key)
+
+    name = Keyword.fetch!(options, :name)
+    Supervisor.start_link(__MODULE__, options, name: name)
+  end
+
+  defp validate_sdk_key(nil), do: raise(ArgumentError, "SDK Key is required")
+  defp validate_sdk_key(""), do: raise(ArgumentError, "SDK Key is required")
+  defp validate_sdk_key(sdk_key) when is_binary(sdk_key), do: :ok
+
+  defp default_options,
+    do: [
+      cache: @default_cache,
+      cache_policy: CachePolicy.auto(),
+      flag_overrides: NullDataSource.new(),
+      name: ConfigCat,
+      offline: false
+    ]
+
+  @impl Supervisor
+  def init(options) do
+    fetcher_options = fetcher_options(options)
+
+    policy_options =
+      options
+      |> Keyword.put(:fetcher_id, fetcher_options[:name])
+      |> cache_policy_options()
+
+    client_options =
+      options
+      |> Keyword.put(:cache_policy_id, policy_options[:name])
+      |> client_options()
+
+    override_behaviour = OverrideDataSource.behaviour(options[:flag_overrides])
+
+    children =
+      [
+        default_cache(options),
+        config_fetcher(fetcher_options, override_behaviour),
+        cache_policy(policy_options, override_behaviour),
+        {Client, client_options}
+      ]
+      |> Enum.reject(&is_nil/1)
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp default_cache(options) do
+    case Keyword.get(options, :cache) do
+      @default_cache -> {@default_cache, cache_options(options)}
+      _ -> nil
+    end
+  end
+
+  defp config_fetcher(_options, :local_only), do: nil
+
+  defp config_fetcher(options, _override_behaviour) do
+    {CacheControlConfigFetcher, options}
+  end
+
+  defp cache_policy(_options, :local_only), do: nil
+
+  defp cache_policy(options, _override_behaviour) do
+    {CachePolicy, options}
+  end
+
+  @spec client_name(atom()) :: atom()
+  def client_name(name), do: :"#{name}.Client"
+
+  defp cache_policy_name(name), do: :"#{name}.CachePolicy"
+  defp fetcher_name(name), do: :"#{name}.ConfigFetcher"
+
+  defp generate_cache_key(options, sdk_key) do
+    prefix =
+      case Keyword.get(options, :cache) do
+        @default_cache -> options[:name]
+        _ -> "elixir_"
+      end
+
+    cache_key =
+      :crypto.hash(:sha, "#{prefix}_#{ConfigCat.Constants.config_filename()}_#{sdk_key}")
+      |> Base.encode16()
+
+    Keyword.put(options, :cache_key, cache_key)
+  end
+
+  defp cache_options(options) do
+    Keyword.take(options, [:cache_key])
+  end
+
+  defp cache_policy_options(options) do
+    options
+    |> Keyword.update!(:name, &cache_policy_name/1)
+    |> Keyword.take([:cache, :cache_key, :cache_policy, :fetcher_id, :name, :offline])
+  end
+
+  defp client_options(options) do
+    options
+    |> Keyword.update!(:name, &client_name/1)
+    |> Keyword.update!(:cache_policy, &CachePolicy.policy_name/1)
+    |> Keyword.take([
+      :cache_policy,
+      :cache_policy_id,
+      :default_user,
+      :flag_overrides,
+      :name
+    ])
+  end
+
+  defp fetcher_options(options) do
+    options
+    |> Keyword.update!(:name, &fetcher_name/1)
+    |> Keyword.put(:mode, options[:cache_policy].mode)
+    |> Keyword.take([
+      :base_url,
+      :http_proxy,
+      :connect_timeout_milliseconds,
+      :read_timeout_milliseconds,
+      :data_governance,
+      :mode,
+      :name,
+      :sdk_key
+    ])
+  end
+end

--- a/test/config_cat/default_user_test.exs
+++ b/test/config_cat/default_user_test.exs
@@ -41,17 +41,17 @@ defmodule ConfigCat.DefaultUserTest do
     end
 
     test "get_value/4 uses the default user if no user is passed", %{client: client} do
-      assert Client.get_value(client, "testStringKey", "") == "fake1"
+      assert ConfigCat.get_value("testStringKey", "", client: client) == "fake1"
     end
 
     test "get_value/4 uses the passed user", %{client: client} do
       user = User.new("test@test2.com")
-      assert Client.get_value(client, "testStringKey", "", user) == "fake2"
+      assert ConfigCat.get_value("testStringKey", "", user, client: client) == "fake2"
     end
 
     test "get_value/4 uses the undefined user case if default user is cleared", %{client: client} do
-      Client.clear_default_user(client)
-      assert Client.get_value(client, "testStringKey", "") == "testValue"
+      ConfigCat.clear_default_user(client: client)
+      assert ConfigCat.get_value("testStringKey", "", client: client) == "testValue"
     end
 
     test "get_all_values/1 uses the default user if no user is passed", %{client: client} do
@@ -62,7 +62,7 @@ defmodule ConfigCat.DefaultUserTest do
         }
         |> Enum.sort()
 
-      actual = client |> Client.get_all_values() |> Enum.sort()
+      actual = ConfigCat.get_all_values(nil, client: client) |> Enum.sort()
       assert actual == expected
     end
 
@@ -75,7 +75,7 @@ defmodule ConfigCat.DefaultUserTest do
         |> Enum.sort()
 
       user = User.new("test@test2.com")
-      actual = client |> Client.get_all_values(user) |> Enum.sort()
+      actual = ConfigCat.get_all_values(user, client: client) |> Enum.sort()
       assert actual == expected
     end
   end
@@ -87,17 +87,17 @@ defmodule ConfigCat.DefaultUserTest do
     end
 
     test "get_value/4 uses the undefined user case if no user is passed", %{client: client} do
-      assert Client.get_value(client, "testStringKey", "") == "testValue"
+      assert ConfigCat.get_value("testStringKey", "", client: client) == "testValue"
     end
 
     test "get_value/4 uses the passed user", %{client: client} do
       user = User.new("test@test2.com")
-      assert Client.get_value(client, "testStringKey", "", user) == "fake2"
+      assert ConfigCat.get_value("testStringKey", "", user, client: client) == "fake2"
     end
 
     test "get_value/4 uses the default user if no user is passed", %{client: client} do
-      Client.set_default_user(client, User.new("test@test1.com"))
-      assert Client.get_value(client, "testStringKey", "") == "fake1"
+      ConfigCat.set_default_user(User.new("test@test1.com"), client: client)
+      assert ConfigCat.get_value("testStringKey", "", client: client) == "fake1"
     end
 
     test "get_all_values/1 uses the undefined user case if no user is passed", %{client: client} do
@@ -108,7 +108,7 @@ defmodule ConfigCat.DefaultUserTest do
         }
         |> Enum.sort()
 
-      actual = client |> Client.get_all_values() |> Enum.sort()
+      actual = ConfigCat.get_all_values(nil, client: client) |> Enum.sort()
       assert actual == expected
     end
 
@@ -121,13 +121,14 @@ defmodule ConfigCat.DefaultUserTest do
         |> Enum.sort()
 
       user = User.new("test@test2.com")
-      actual = client |> Client.get_all_values(user) |> Enum.sort()
+      actual = ConfigCat.get_all_values(user, client: client) |> Enum.sort()
       assert actual == expected
     end
   end
 
   defp start_client(default_user \\ nil) do
-    name = UUID.uuid4() |> String.to_atom()
+    base_name = UUID.uuid4() |> String.to_atom()
+    name = ConfigCat.Supervisor.client_name(base_name)
 
     options = [
       cache_policy: MockCachePolicy,
@@ -141,6 +142,6 @@ defmodule ConfigCat.DefaultUserTest do
 
     allow(MockCachePolicy, self(), name)
 
-    {:ok, name}
+    {:ok, base_name}
   end
 end

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -1,4 +1,4 @@
-defmodule ConfigCat.ClientTest do
+defmodule ConfigCatTest do
   use ExUnit.Case, async: true
 
   import Mox
@@ -41,53 +41,53 @@ defmodule ConfigCat.ClientTest do
 
     test "get_all_keys/1 returns all known keys", %{client: client} do
       expected = ~w(testBoolKey testStringKey testIntKey testDoubleKey key1 key2) |> Enum.sort()
-      actual = client |> Client.get_all_keys() |> Enum.sort()
+      actual = ConfigCat.get_all_keys(client: client) |> Enum.sort()
       assert actual == expected
     end
 
     test "get_value/4 returns a boolean value", %{client: client} do
-      assert Client.get_value(client, "testBoolKey", false) == true
+      assert ConfigCat.get_value("testBoolKey", false, client: client) == true
     end
 
     test "get_value/4 returns a string value", %{client: client} do
-      assert Client.get_value(client, "testStringKey", "default") == "testValue"
+      assert ConfigCat.get_value("testStringKey", "default", client: client) == "testValue"
     end
 
     test "get_value/4 returns an integer value", %{client: client} do
-      assert Client.get_value(client, "testIntKey", 0) == 1
+      assert ConfigCat.get_value("testIntKey", 0, client: client) == 1
     end
 
     test "get_value/4 returns a double value", %{client: client} do
-      assert Client.get_value(client, "testDoubleKey", 0.0) == 1.1
+      assert ConfigCat.get_value("testDoubleKey", 0.0, client: client) == 1.1
     end
 
     @tag capture_log: true
     test "get_value/4 returns default value if key not found", %{client: client} do
-      assert Client.get_value(client, "testUnknownKey", "default") == "default"
+      assert ConfigCat.get_value("testUnknownKey", "default", client: client) == "default"
     end
 
     test "get_variation_id/4 looks up the variation id for a key", %{client: client} do
-      assert Client.get_variation_id(client, "key1", nil) == "fakeId1"
-      assert Client.get_variation_id(client, "key2", nil) == "fakeId2"
+      assert ConfigCat.get_variation_id("key1", nil, client: client) == "fakeId1"
+      assert ConfigCat.get_variation_id("key2", nil, client: client) == "fakeId2"
     end
 
     @tag capture_log: true
     test "get_variation_id/4 returns default if variation id not found", %{client: client} do
-      assert Client.get_variation_id(client, "nonexisting", "default_variation_id") ==
+      assert ConfigCat.get_variation_id("nonexisting", "default_variation_id", client: client) ==
                "default_variation_id"
     end
 
     test "get_all_variation_ids/1 returns all known variation ids", %{client: client} do
       expected = ~w(fakeId1 fakeId2) |> Enum.sort()
-      actual = client |> Client.get_all_variation_ids() |> Enum.sort()
+      actual = ConfigCat.get_all_variation_ids(client: client) |> Enum.sort()
       assert actual == expected
     end
 
     test "get_key_and_value/2 returns matching key/value pair for a variation id", %{
       client: client
     } do
-      assert {"key1", true} = Client.get_key_and_value(client, "fakeId1")
-      assert {"key2", false} = Client.get_key_and_value(client, "fakeId2")
+      assert {"key1", true} = ConfigCat.get_key_and_value("fakeId1", client: client)
+      assert {"key2", false} = ConfigCat.get_key_and_value("fakeId2", client: client)
     end
 
     test "get_all_values/1 returns all key/value pairs", %{client: client} do
@@ -102,7 +102,7 @@ defmodule ConfigCat.ClientTest do
         }
         |> Enum.sort()
 
-      actual = client |> Client.get_all_values() |> Enum.sort()
+      actual = ConfigCat.get_all_values(nil, client: client) |> Enum.sort()
       assert actual == expected
     end
   end
@@ -118,33 +118,34 @@ defmodule ConfigCat.ClientTest do
     end
 
     test "get_all_keys/1 returns an empty list of keys", %{client: client} do
-      assert Client.get_all_keys(client) == []
+      assert ConfigCat.get_all_keys(client: client) == []
     end
 
     test "get_value/4 returns default value", %{client: client} do
-      assert Client.get_value(client, "any_feature", "default") == "default"
+      assert ConfigCat.get_value("any_feature", "default", client: client) == "default"
     end
 
     test "get_variation_id/4 returns default variation", %{client: client} do
-      assert Client.get_variation_id(client, "any_feature", "default") == "default"
+      assert ConfigCat.get_variation_id("any_feature", "default", client: client) == "default"
     end
 
     test "get_all_variation_ids/2 returns an empty list of variation ids", %{client: client} do
-      assert Client.get_all_variation_ids(client) == []
+      assert ConfigCat.get_all_variation_ids(client: client) == []
     end
 
     @tag capture_log: true
     test "get_key_and_value/2 returns nil", %{client: client} do
-      assert Client.get_key_and_value(client, "any_variation") == nil
+      assert ConfigCat.get_key_and_value("any_variation", client: client) == nil
     end
 
     test "get_all_values/1 returns an empty map", %{client: client} do
-      assert Client.get_all_values(client) == %{}
+      assert ConfigCat.get_all_values(nil, client: client) == %{}
     end
   end
 
   defp start_client do
-    name = UUID.uuid4() |> String.to_atom()
+    base_name = UUID.uuid4() |> String.to_atom()
+    name = ConfigCat.Supervisor.client_name(base_name)
 
     options = [
       cache_policy: MockCachePolicy,
@@ -157,6 +158,6 @@ defmodule ConfigCat.ClientTest do
 
     allow(MockCachePolicy, self(), name)
 
-    {:ok, name}
+    {:ok, base_name}
   end
 end

--- a/test/flag_override_test.exs
+++ b/test/flag_override_test.exs
@@ -35,11 +35,11 @@ defmodule ConfigCat.FlagOverrideTest do
 
       {:ok, client} = start_client(overrides)
 
-      assert Client.get_value(client, "enabledFeature", false) == true
-      assert Client.get_value(client, "disabledFeature", true) == false
-      assert Client.get_value(client, "intSetting", 0) == 5
-      assert Client.get_value(client, "doubleSetting", 0.0) == 3.14
-      assert Client.get_value(client, "stringSetting", "") == "test"
+      assert ConfigCat.get_value("enabledFeature", false, client: client) == true
+      assert ConfigCat.get_value("disabledFeature", true, client: client) == false
+      assert ConfigCat.get_value("intSetting", 0, client: client) == 5
+      assert ConfigCat.get_value("doubleSetting", 0.0, client: client) == 3.14
+      assert ConfigCat.get_value("stringSetting", "", client: client) == "test"
     end
 
     test "uses flag values from a simple-format local file" do
@@ -48,11 +48,11 @@ defmodule ConfigCat.FlagOverrideTest do
 
       {:ok, client} = start_client(overrides)
 
-      assert Client.get_value(client, "enabledFeature", false) == true
-      assert Client.get_value(client, "disabledFeature", true) == false
-      assert Client.get_value(client, "intSetting", 0) == 5
-      assert Client.get_value(client, "doubleSetting", 0.0) == 3.14
-      assert Client.get_value(client, "stringSetting", "") == "test"
+      assert ConfigCat.get_value("enabledFeature", false, client: client) == true
+      assert ConfigCat.get_value("disabledFeature", true, client: client) == false
+      assert ConfigCat.get_value("intSetting", 0, client: client) == 5
+      assert ConfigCat.get_value("doubleSetting", 0.0, client: client) == 3.14
+      assert ConfigCat.get_value("stringSetting", "", client: client) == "test"
     end
 
     test "reloads file when modified" do
@@ -71,7 +71,7 @@ defmodule ConfigCat.FlagOverrideTest do
       stat = File.stat!(filename, time: :posix)
       File.touch!(filename, stat.mtime - 1)
 
-      assert Client.get_value(client, "enabledFeature", true) == false
+      assert ConfigCat.get_value("enabledFeature", true, client: client) == false
 
       modified_flags = put_in(flags, ["flags", "enabledFeature"], true)
 
@@ -79,7 +79,7 @@ defmodule ConfigCat.FlagOverrideTest do
         IO.write(file, Jason.encode!(modified_flags))
       end)
 
-      assert Client.get_value(client, "enabledFeature", false) == true
+      assert ConfigCat.get_value("enabledFeature", false, client: client) == true
     end
 
     test "uses default value if override file doesn't exist" do
@@ -88,7 +88,7 @@ defmodule ConfigCat.FlagOverrideTest do
 
       {:ok, client} = start_client(overrides)
 
-      assert Client.get_value(client, "enabledFeature", false) == false
+      assert ConfigCat.get_value("enabledFeature", false, client: client) == false
     end
 
     test "uses default value if override file is invalid" do
@@ -102,7 +102,7 @@ defmodule ConfigCat.FlagOverrideTest do
         IO.write(file, invalid_contents)
       end)
 
-      assert Client.get_value(client, "enabledFeature", false) == false
+      assert ConfigCat.get_value("enabledFeature", false, client: client) == false
     end
 
     test "uses flag values from a map" do
@@ -118,11 +118,11 @@ defmodule ConfigCat.FlagOverrideTest do
 
       {:ok, client} = start_client(overrides)
 
-      assert Client.get_value(client, "enabledFeature", false) == true
-      assert Client.get_value(client, "disabledFeature", true) == false
-      assert Client.get_value(client, "intSetting", 0) == 5
-      assert Client.get_value(client, "doubleSetting", 0.0) == 3.14
-      assert Client.get_value(client, "stringSetting", "") == "test"
+      assert ConfigCat.get_value("enabledFeature", false, client: client) == true
+      assert ConfigCat.get_value("disabledFeature", true, client: client) == false
+      assert ConfigCat.get_value("intSetting", 0, client: client) == 5
+      assert ConfigCat.get_value("doubleSetting", 0.0, client: client) == 3.14
+      assert ConfigCat.get_value("stringSetting", "", client: client) == "test"
     end
   end
 
@@ -137,8 +137,8 @@ defmodule ConfigCat.FlagOverrideTest do
 
       {:ok, client} = start_client(overrides)
 
-      assert Client.get_value(client, "fakeKey", false) == true
-      assert Client.get_value(client, "nonexisting", false) == true
+      assert ConfigCat.get_value("fakeKey", false, client: client) == true
+      assert ConfigCat.get_value("nonexisting", false, client: client) == true
     end
   end
 
@@ -153,8 +153,8 @@ defmodule ConfigCat.FlagOverrideTest do
 
       {:ok, client} = start_client(overrides)
 
-      assert Client.get_value(client, "fakeKey", true) == false
-      assert Client.get_value(client, "nonexisting", false) == true
+      assert ConfigCat.get_value("fakeKey", true, client: client) == false
+      assert ConfigCat.get_value("nonexisting", false, client: client) == true
     end
   end
 
@@ -173,7 +173,8 @@ defmodule ConfigCat.FlagOverrideTest do
   end
 
   defp start_client(flag_overrides) do
-    name = UUID.uuid4() |> String.to_atom()
+    base_name = UUID.uuid4() |> String.to_atom()
+    name = ConfigCat.Supervisor.client_name(base_name)
 
     options = [
       cache_policy: MockCachePolicy,
@@ -186,6 +187,6 @@ defmodule ConfigCat.FlagOverrideTest do
 
     allow(MockCachePolicy, self(), name)
 
-    {:ok, name}
+    {:ok, base_name}
   end
 end


### PR DESCRIPTION
### Describe the purpose of your pull request

Clean up the overall structure of the application to make it easier to maintain and add new features.

- Extract the main supervisor to its own module; separates the responsibility of starting/supervising the app from the public API.
- Add a delegator `child_spec` function to `ConfigCat` so that client apps can continue to include `ConfigCat` in their supervision trees (rather than having to change to use `ConfigCat.Supervisor`.
More to come in a follow-up PR.
- Extract a helper for deriving a client's name from the provided options.
- Modify Client tests to test through the public API instead.
- Inline `Client`s API into `ConfigCat`: Every time we added new public API to ConfigCat, we had to add it to both ConfigCat and ConfigCat.Client. This inlines the `GenServer.call/cast` calls up into ConfigCat to eliminate this extra layer of indirection. It's not the normal way of doing things in Elixir, but in this case it seems to make sense to do it this way.

I have one or two other simplifications to implement, but I'll do those in separate PRs.

### Related issues (only if applicable)

Will simplify work on upcoming issues.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
