### PR TITLE
♻️ Use a Registry for finding related processes

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -172,11 +172,10 @@ defmodule ConfigCat do
   alias ConfigCat.CachePolicy
   alias ConfigCat.Client
   alias ConfigCat.Config
-  alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource
   alias ConfigCat.User
 
-  require Constants
+  require ConfigCat.Constants, as: Constants
 
   @typedoc "Options that can be passed to all API functions."
   @type api_option :: {:client, instance_id()}

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -170,6 +170,7 @@ defmodule ConfigCat do
   """
 
   alias ConfigCat.CachePolicy
+  alias ConfigCat.Client
   alias ConfigCat.Config
   alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource
@@ -504,6 +505,6 @@ defmodule ConfigCat do
   defp client(options) do
     options
     |> Keyword.get(:client, __MODULE__)
-    |> ConfigCat.Supervisor.client_name()
+    |> Client.via_tuple()
   end
 end

--- a/lib/config_cat/application.ex
+++ b/lib/config_cat/application.ex
@@ -1,0 +1,13 @@
+defmodule ConfigCat.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl Application
+  def start(_type, _args) do
+    children = [{Registry, keys: :unique, name: ConfigCat.Registry}]
+
+    opts = [strategy: :one_for_one, name: ConfigCat.RegistrySupervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -48,9 +48,6 @@ defmodule ConfigCat.CachePolicy do
           | {:poll_interval_seconds, pos_integer()}
         ]
 
-  @typedoc false
-  @type id :: atom()
-
   @typedoc "Options for lazy-polling mode."
   @type lazy_options :: [{:cache_expiry_seconds, non_neg_integer()}]
 
@@ -63,7 +60,7 @@ defmodule ConfigCat.CachePolicy do
           | {:cache_key, ConfigCache.key()}
           | {:cache_policy, t()}
           | {:fetcher, module()}
-          | {:id, ConfigCat.instance_id()}
+          | {:instance_id, ConfigCat.instance_id()}
           | {:offline, boolean()}
 
   @typedoc false

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -63,7 +63,7 @@ defmodule ConfigCat.CachePolicy do
           | {:cache_key, ConfigCache.key()}
           | {:cache_policy, t()}
           | {:fetcher, module()}
-          | {:fetcher_id, ConfigFetcher.id()}
+          | {:id, ConfigCat.instance_id()}
           | {:name, id()}
           | {:offline, boolean()}
 

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -64,7 +64,6 @@ defmodule ConfigCat.CachePolicy do
           | {:cache_policy, t()}
           | {:fetcher, module()}
           | {:id, ConfigCat.instance_id()}
-          | {:name, id()}
           | {:offline, boolean()}
 
   @typedoc false
@@ -157,11 +156,5 @@ defmodule ConfigCat.CachePolicy do
   @spec child_spec(options()) :: Supervisor.child_spec()
   def child_spec(options) do
     policy_name(options).child_spec(options)
-  end
-
-  @doc false
-  @spec start_link(options()) :: GenServer.on_start()
-  def start_link(options) do
-    policy_name(options).start_link(options)
   end
 end

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -34,6 +34,10 @@ defmodule ConfigCat.CachePolicy.Auto do
     Helpers.start_link(__MODULE__, options)
   end
 
+  defp via_tuple(id) do
+    Helpers.via_tuple(__MODULE__, id)
+  end
+
   @impl GenServer
   def init(state) do
     {:ok, state, {:continue, :initial_fetch}}
@@ -64,28 +68,38 @@ defmodule ConfigCat.CachePolicy.Auto do
   end
 
   @impl Behaviour
-  def get(policy_id) do
-    GenServer.call(policy_id, :get, Constants.fetch_timeout())
+  def get(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:get, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def is_offline(policy_id) do
-    GenServer.call(policy_id, :is_offline, Constants.fetch_timeout())
+  def is_offline(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_offline(policy_id) do
-    GenServer.call(policy_id, :set_offline, Constants.fetch_timeout())
+  def set_offline(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_online(policy_id) do
-    GenServer.call(policy_id, :set_online, Constants.fetch_timeout())
+  def set_online(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def force_refresh(policy_id) do
-    GenServer.call(policy_id, :force_refresh, Constants.fetch_timeout())
+  def force_refresh(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -1,14 +1,12 @@
 defmodule ConfigCat.CachePolicy.Auto do
   @moduledoc false
 
+  use ConfigCat.CachePolicy.Behaviour
   use GenServer
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Behaviour
   alias ConfigCat.CachePolicy.Helpers
-  alias ConfigCat.Constants
 
-  require Constants
   require Logger
 
   defstruct mode: "a", on_changed: nil, poll_interval_seconds: 60
@@ -21,21 +19,10 @@ defmodule ConfigCat.CachePolicy.Auto do
           poll_interval_seconds: pos_integer()
         }
 
-  @behaviour Behaviour
-
   @spec new(options()) :: t()
   def new(options \\ []) do
     struct(__MODULE__, options)
     |> Map.update!(:poll_interval_seconds, &max(&1, 1))
-  end
-
-  @spec start_link(CachePolicy.options()) :: GenServer.on_start()
-  def start_link(options) do
-    Helpers.start_link(__MODULE__, options)
-  end
-
-  defp via_tuple(instance_id) do
-    Helpers.via_tuple(__MODULE__, instance_id)
   end
 
   @impl GenServer
@@ -65,41 +52,6 @@ defmodule ConfigCat.CachePolicy.Auto do
     end
 
     {:noreply, state}
-  end
-
-  @impl Behaviour
-  def get(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:get, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def is_offline(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:is_offline, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def set_offline(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:set_offline, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def set_online(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:set_online, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def force_refresh(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -34,8 +34,8 @@ defmodule ConfigCat.CachePolicy.Auto do
     Helpers.start_link(__MODULE__, options)
   end
 
-  defp via_tuple(id) do
-    Helpers.via_tuple(__MODULE__, id)
+  defp via_tuple(instance_id) do
+    Helpers.via_tuple(__MODULE__, instance_id)
   end
 
   @impl GenServer
@@ -68,36 +68,36 @@ defmodule ConfigCat.CachePolicy.Auto do
   end
 
   @impl Behaviour
-  def get(id) do
-    id
+  def get(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:get, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def is_offline(id) do
-    id
+  def is_offline(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_offline(id) do
-    id
+  def set_offline(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_online(id) do
-    id
+  def set_online(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def force_refresh(id) do
-    id
+  def force_refresh(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -4,12 +4,11 @@ defmodule ConfigCat.CachePolicy.Behaviour do
   alias ConfigCat.CachePolicy
   alias ConfigCat.Config
 
-  @type id :: CachePolicy.id()
   @type refresh_result :: CachePolicy.refresh_result()
 
-  @callback get(id()) :: {:ok, Config.t()} | {:error, :not_found}
-  @callback is_offline(id()) :: boolean()
-  @callback set_offline(id()) :: :ok
-  @callback set_online(id()) :: :ok
-  @callback force_refresh(id()) :: refresh_result()
+  @callback get(ConfigCat.instance_id()) :: {:ok, Config.t()} | {:error, :not_found}
+  @callback is_offline(ConfigCat.instance_id()) :: boolean()
+  @callback set_offline(ConfigCat.instance_id()) :: :ok
+  @callback set_online(ConfigCat.instance_id()) :: :ok
+  @callback force_refresh(ConfigCat.instance_id()) :: refresh_result()
 end

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -2,6 +2,8 @@ defmodule ConfigCat.CachePolicy.Behaviour do
   @moduledoc false
 
   alias ConfigCat.CachePolicy
+  alias ConfigCat.CachePolicy.Behaviour
+  alias ConfigCat.CachePolicy.Helpers
   alias ConfigCat.Config
 
   @type refresh_result :: CachePolicy.refresh_result()
@@ -11,4 +13,56 @@ defmodule ConfigCat.CachePolicy.Behaviour do
   @callback set_offline(ConfigCat.instance_id()) :: :ok
   @callback set_online(ConfigCat.instance_id()) :: :ok
   @callback force_refresh(ConfigCat.instance_id()) :: refresh_result()
+
+  defmacro __using__(_opts) do
+    quote location: :keep do
+      require ConfigCat.Constants, as: Constants
+
+      @behaviour Behaviour
+
+      @spec start_link(CachePolicy.options()) :: GenServer.on_start()
+      def start_link(options) do
+        Helpers.start_link(__MODULE__, options)
+      end
+
+      @impl Behaviour
+      def get(instance_id) do
+        instance_id
+        |> via_tuple()
+        |> GenServer.call(:get, Constants.fetch_timeout())
+      end
+
+      @impl Behaviour
+      def is_offline(instance_id) do
+        instance_id
+        |> via_tuple()
+        |> GenServer.call(:is_offline, Constants.fetch_timeout())
+      end
+
+      @impl Behaviour
+      def set_offline(instance_id) do
+        instance_id
+        |> via_tuple()
+        |> GenServer.call(:set_offline, Constants.fetch_timeout())
+      end
+
+      @impl Behaviour
+      def set_online(instance_id) do
+        instance_id
+        |> via_tuple()
+        |> GenServer.call(:set_online, Constants.fetch_timeout())
+      end
+
+      @impl Behaviour
+      def force_refresh(instance_id) do
+        instance_id
+        |> via_tuple()
+        |> GenServer.call(:force_refresh, Constants.fetch_timeout())
+      end
+
+      defp via_tuple(instance_id) do
+        Helpers.via_tuple(__MODULE__, instance_id)
+      end
+    end
+  end
 end

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -9,17 +9,21 @@ defmodule ConfigCat.CachePolicy.Helpers do
           :cache_key => ConfigCache.key(),
           :fetcher => module(),
           :id => ConfigCat.instance_id(),
-          :name => CachePolicy.id(),
           :offline => false,
           optional(atom()) => any()
         }
 
   @spec start_link(module(), CachePolicy.options(), map()) :: GenServer.on_start()
   def start_link(module, options, additional_state \\ %{}) do
-    name = Keyword.fetch!(options, :name)
+    id = Keyword.fetch!(options, :id)
     initial_state = make_initial_state(options, additional_state)
 
-    GenServer.start_link(module, initial_state, name: name)
+    GenServer.start_link(module, initial_state, name: via_tuple(module, id))
+  end
+
+  @spec via_tuple(module(), ConfigCat.instance_id()) :: {:via, module(), term()}
+  def via_tuple(module, id) do
+    {:via, Registry, {ConfigCat.Registry, {module, id}}}
   end
 
   defp make_initial_state(options, additional_state) do

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -8,22 +8,22 @@ defmodule ConfigCat.CachePolicy.Helpers do
           :cache => module(),
           :cache_key => ConfigCache.key(),
           :fetcher => module(),
-          :id => ConfigCat.instance_id(),
+          :instance_id => ConfigCat.instance_id(),
           :offline => false,
           optional(atom()) => any()
         }
 
   @spec start_link(module(), CachePolicy.options(), map()) :: GenServer.on_start()
   def start_link(module, options, additional_state \\ %{}) do
-    id = Keyword.fetch!(options, :id)
+    instance_id = Keyword.fetch!(options, :instance_id)
     initial_state = make_initial_state(options, additional_state)
 
-    GenServer.start_link(module, initial_state, name: via_tuple(module, id))
+    GenServer.start_link(module, initial_state, name: via_tuple(module, instance_id))
   end
 
   @spec via_tuple(module(), ConfigCat.instance_id()) :: {:via, module(), term()}
-  def via_tuple(module, id) do
-    {:via, Registry, {ConfigCat.Registry, {module, id}}}
+  def via_tuple(module, instance_id) do
+    {:via, Registry, {ConfigCat.Registry, {module, instance_id}}}
   end
 
   defp make_initial_state(options, additional_state) do
@@ -35,7 +35,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
     default_options()
     |> Keyword.merge(options)
-    |> Keyword.take([:cache, :cache_key, :fetcher, :id, :offline])
+    |> Keyword.take([:cache, :cache_key, :fetcher, :instance_id, :offline])
     |> Map.new()
     |> Map.merge(policy_options)
     |> Map.merge(additional_state)
@@ -55,7 +55,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
   def refresh_config(state) do
     fetcher = Map.fetch!(state, :fetcher)
 
-    case fetcher.fetch(state.id) do
+    case fetcher.fetch(state.instance_id) do
       {:ok, :unchanged} ->
         :ok
 

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -13,10 +13,10 @@ defmodule ConfigCat.CachePolicy.Helpers do
           optional(atom()) => any()
         }
 
-  @spec start_link(module(), CachePolicy.options(), map()) :: GenServer.on_start()
-  def start_link(module, options, additional_state \\ %{}) do
+  @spec start_link(module(), CachePolicy.options()) :: GenServer.on_start()
+  def start_link(module, options) do
     instance_id = Keyword.fetch!(options, :instance_id)
-    initial_state = make_initial_state(options, additional_state)
+    initial_state = make_initial_state(options)
 
     GenServer.start_link(module, initial_state, name: via_tuple(module, instance_id))
   end
@@ -26,7 +26,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
     {:via, Registry, {ConfigCat.Registry, {module, instance_id}}}
   end
 
-  defp make_initial_state(options, additional_state) do
+  defp make_initial_state(options) do
     policy_options =
       options
       |> Keyword.fetch!(:cache_policy)
@@ -38,7 +38,6 @@ defmodule ConfigCat.CachePolicy.Helpers do
     |> Keyword.take([:cache, :cache_key, :fetcher, :instance_id, :offline])
     |> Map.new()
     |> Map.merge(policy_options)
-    |> Map.merge(additional_state)
   end
 
   defp default_options, do: [fetcher: ConfigCat.CacheControlConfigFetcher]

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -3,13 +3,12 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
   alias ConfigCat.CachePolicy
   alias ConfigCat.ConfigCache
-  alias ConfigCat.ConfigFetcher
 
   @type state :: %{
           :cache => module(),
           :cache_key => ConfigCache.key(),
           :fetcher => module(),
-          :fetcher_id => ConfigFetcher.id(),
+          :id => ConfigCat.instance_id(),
           :name => CachePolicy.id(),
           :offline => false,
           optional(atom()) => any()
@@ -32,7 +31,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
     default_options()
     |> Keyword.merge(options)
-    |> Keyword.take([:cache, :cache_key, :fetcher, :fetcher_id, :offline])
+    |> Keyword.take([:cache, :cache_key, :fetcher, :id, :offline])
     |> Map.new()
     |> Map.merge(policy_options)
     |> Map.merge(additional_state)
@@ -51,9 +50,8 @@ defmodule ConfigCat.CachePolicy.Helpers do
   @spec refresh_config(state()) :: CachePolicy.refresh_result()
   def refresh_config(state) do
     fetcher = Map.fetch!(state, :fetcher)
-    fetcher_id = Map.fetch!(state, :fetcher_id)
 
-    case fetcher.fetch(fetcher_id) do
+    case fetcher.fetch(state.id) do
       {:ok, :unchanged} ->
         :ok
 

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -32,8 +32,8 @@ defmodule ConfigCat.CachePolicy.Lazy do
     Helpers.start_link(__MODULE__, options, %{last_update: nil})
   end
 
-  defp via_tuple(id) do
-    Helpers.via_tuple(__MODULE__, id)
+  defp via_tuple(instance_id) do
+    Helpers.via_tuple(__MODULE__, instance_id)
   end
 
   @impl GenServer
@@ -42,36 +42,36 @@ defmodule ConfigCat.CachePolicy.Lazy do
   end
 
   @impl Behaviour
-  def get(id) do
-    id
+  def get(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:get, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def is_offline(id) do
-    id
+  def is_offline(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_offline(id) do
-    id
+  def set_offline(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_online(id) do
-    id
+  def set_online(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def force_refresh(id) do
-    id
+  def force_refresh(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -1,14 +1,11 @@
 defmodule ConfigCat.CachePolicy.Lazy do
   @moduledoc false
 
+  use ConfigCat.CachePolicy.Behaviour
   use GenServer
 
-  alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Behaviour
   alias ConfigCat.CachePolicy.Helpers
-  alias ConfigCat.Constants
 
-  require Constants
   require Logger
 
   @enforce_keys [:cache_expiry_seconds]
@@ -20,60 +17,15 @@ defmodule ConfigCat.CachePolicy.Lazy do
           mode: String.t()
         }
 
-  @behaviour Behaviour
-
   @spec new(options()) :: t()
   def new(options) do
     struct(__MODULE__, options)
   end
 
-  @spec start_link(CachePolicy.options()) :: GenServer.on_start()
-  def start_link(options) do
-    Helpers.start_link(__MODULE__, options, %{last_update: nil})
-  end
-
-  defp via_tuple(instance_id) do
-    Helpers.via_tuple(__MODULE__, instance_id)
-  end
-
   @impl GenServer
   def init(state) do
+    state = Map.put(state, :last_update, nil)
     {:ok, state}
-  end
-
-  @impl Behaviour
-  def get(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:get, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def is_offline(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:is_offline, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def set_offline(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:set_offline, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def set_online(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:set_online, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def force_refresh(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -32,34 +32,48 @@ defmodule ConfigCat.CachePolicy.Lazy do
     Helpers.start_link(__MODULE__, options, %{last_update: nil})
   end
 
+  defp via_tuple(id) do
+    Helpers.via_tuple(__MODULE__, id)
+  end
+
   @impl GenServer
   def init(state) do
     {:ok, state}
   end
 
   @impl Behaviour
-  def get(policy_id) do
-    GenServer.call(policy_id, :get, Constants.fetch_timeout())
+  def get(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:get, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def is_offline(policy_id) do
-    GenServer.call(policy_id, :is_offline, Constants.fetch_timeout())
+  def is_offline(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_offline(policy_id) do
-    GenServer.call(policy_id, :set_offline, Constants.fetch_timeout())
+  def set_offline(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_online(policy_id) do
-    GenServer.call(policy_id, :set_online, Constants.fetch_timeout())
+  def set_online(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def force_refresh(policy_id) do
-    GenServer.call(policy_id, :force_refresh, Constants.fetch_timeout())
+  def force_refresh(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -1,74 +1,25 @@
 defmodule ConfigCat.CachePolicy.Manual do
   @moduledoc false
 
+  use ConfigCat.CachePolicy.Behaviour
   use GenServer
 
-  alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Behaviour
   alias ConfigCat.CachePolicy.Helpers
-  alias ConfigCat.Constants
 
-  require Constants
   require Logger
 
   defstruct mode: "m"
 
   @type t :: %__MODULE__{mode: String.t()}
 
-  @behaviour Behaviour
-
   @spec new :: t()
   def new do
     %__MODULE__{}
   end
 
-  @spec start_link(CachePolicy.options()) :: GenServer.on_start()
-  def start_link(options) do
-    Helpers.start_link(__MODULE__, options)
-  end
-
-  defp via_tuple(instance_id) do
-    Helpers.via_tuple(__MODULE__, instance_id)
-  end
-
   @impl GenServer
   def init(state) do
     {:ok, state}
-  end
-
-  @impl Behaviour
-  def get(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:get)
-  end
-
-  @impl Behaviour
-  def is_offline(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:is_offline, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def set_offline(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:set_offline, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def set_online(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:set_online, Constants.fetch_timeout())
-  end
-
-  @impl Behaviour
-  def force_refresh(instance_id) do
-    instance_id
-    |> via_tuple()
-    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -27,34 +27,48 @@ defmodule ConfigCat.CachePolicy.Manual do
     Helpers.start_link(__MODULE__, options)
   end
 
+  defp via_tuple(id) do
+    Helpers.via_tuple(__MODULE__, id)
+  end
+
   @impl GenServer
   def init(state) do
     {:ok, state}
   end
 
   @impl Behaviour
-  def get(policy_id) do
-    GenServer.call(policy_id, :get)
+  def get(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:get)
   end
 
   @impl Behaviour
-  def is_offline(policy_id) do
-    GenServer.call(policy_id, :is_offline, Constants.fetch_timeout())
+  def is_offline(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_offline(policy_id) do
-    GenServer.call(policy_id, :set_offline, Constants.fetch_timeout())
+  def set_offline(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_online(policy_id) do
-    GenServer.call(policy_id, :set_online, Constants.fetch_timeout())
+  def set_online(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def force_refresh(policy_id) do
-    GenServer.call(policy_id, :force_refresh, Constants.fetch_timeout())
+  def force_refresh(id) do
+    id
+    |> via_tuple()
+    |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -27,8 +27,8 @@ defmodule ConfigCat.CachePolicy.Manual do
     Helpers.start_link(__MODULE__, options)
   end
 
-  defp via_tuple(id) do
-    Helpers.via_tuple(__MODULE__, id)
+  defp via_tuple(instance_id) do
+    Helpers.via_tuple(__MODULE__, instance_id)
   end
 
   @impl GenServer
@@ -37,36 +37,36 @@ defmodule ConfigCat.CachePolicy.Manual do
   end
 
   @impl Behaviour
-  def get(id) do
-    id
+  def get(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:get)
   end
 
   @impl Behaviour
-  def is_offline(id) do
-    id
+  def is_offline(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:is_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_offline(id) do
-    id
+  def set_offline(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:set_offline, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def set_online(id) do
-    id
+  def set_online(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:set_online, Constants.fetch_timeout())
   end
 
   @impl Behaviour
-  def force_refresh(id) do
-    id
+  def force_refresh(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:force_refresh, Constants.fetch_timeout())
   end

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -25,8 +25,13 @@ defmodule ConfigCat.Client do
   @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
     with {name, options} <- Keyword.pop!(options, :name) do
-      GenServer.start_link(__MODULE__, Map.new(options), name: name)
+      GenServer.start_link(__MODULE__, Map.new(options), name: via_tuple(name))
     end
+  end
+
+  @spec via_tuple(client()) :: {:via, module(), term()}
+  def via_tuple(name) do
+    {:via, Registry, {ConfigCat.Registry, {__MODULE__, name}}}
   end
 
   @impl GenServer

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -7,6 +7,7 @@ defmodule ConfigCat.Client do
   alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource
   alias ConfigCat.Rollout
+  alias ConfigCat.User
 
   require Constants
   require Logger
@@ -15,6 +16,7 @@ defmodule ConfigCat.Client do
   @type option ::
           {:cache_policy, module()}
           | {:cache_policy_id, CachePolicy.id()}
+          | {:default_user, User.t()}
           | {:flag_overrides, OverrideDataSource.t()}
           | {:name, client()}
   @type options :: [option]

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -12,26 +12,26 @@ defmodule ConfigCat.Client do
   require Constants
   require Logger
 
-  @type client :: ConfigCat.instance_id()
+  @type id :: ConfigCat.instance_id()
   @type option ::
           {:cache_policy, module()}
           | {:cache_policy_id, CachePolicy.id()}
           | {:default_user, User.t()}
           | {:flag_overrides, OverrideDataSource.t()}
-          | {:name, client()}
+          | {:id, id()}
   @type options :: [option]
   @type refresh_result :: CachePolicy.refresh_result()
 
   @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
-    with {name, options} <- Keyword.pop!(options, :name) do
-      GenServer.start_link(__MODULE__, Map.new(options), name: via_tuple(name))
+    with {id, options} <- Keyword.pop!(options, :id) do
+      GenServer.start_link(__MODULE__, Map.new(options), name: via_tuple(id))
     end
   end
 
-  @spec via_tuple(client()) :: {:via, module(), term()}
-  def via_tuple(name) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, name}}}
+  @spec via_tuple(id()) :: {:via, module(), term()}
+  def via_tuple(id) do
+    {:via, Registry, {ConfigCat.Registry, {__MODULE__, id}}}
   end
 
   @impl GenServer

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -4,12 +4,11 @@ defmodule ConfigCat.Client do
   use GenServer
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource
   alias ConfigCat.Rollout
   alias ConfigCat.User
 
-  require Constants
+  require ConfigCat.Constants, as: Constants
   require Logger
 
   @type option ::

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -61,8 +61,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
     GenServer.start_link(__MODULE__, initial_state, name: via_tuple(id))
   end
 
-  @spec via_tuple(ConfigCat.instance_id()) :: {:via, module(), term()}
-  def via_tuple(id) do
+  defp via_tuple(id) do
     {:via, Registry, {ConfigCat.Registry, {__MODULE__, id}}}
   end
 

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -6,10 +6,9 @@ defmodule ConfigCat.ConfigFetcher do
   alias HTTPoison.Response
 
   @type fetch_error :: {:error, Error.t() | Response.t()}
-  @type id :: atom()
   @type result :: {:ok, Config.t()} | {:ok, :unchanged} | fetch_error()
 
-  @callback fetch(id()) :: result()
+  @callback fetch(ConfigCat.instance_id()) :: result()
 
   defmodule RedirectMode do
     @moduledoc false
@@ -39,7 +38,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
           | {:connect_timeout_milliseconds, non_neg_integer()}
           | {:data_governance, ConfigCat.data_governance()}
           | {:http_proxy, String.t()}
-          | {:id, ConfigCat.instance_id()}
+          | {:instance_id, ConfigCat.instance_id()}
           | {:mode, String.t()}
           | {:read_timeout_milliseconds, non_neg_integer()}
           | {:sdk_key, String.t()}
@@ -49,7 +48,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
 
   @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do
-    {id, options} = Keyword.pop!(options, :id)
+    {instance_id, options} = Keyword.pop!(options, :instance_id)
 
     initial_state =
       default_options()
@@ -58,11 +57,11 @@ defmodule ConfigCat.CacheControlConfigFetcher do
       |> Map.new()
       |> Map.merge(%{etag: nil, redirects: %{}})
 
-    GenServer.start_link(__MODULE__, initial_state, name: via_tuple(id))
+    GenServer.start_link(__MODULE__, initial_state, name: via_tuple(instance_id))
   end
 
-  defp via_tuple(id) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, id}}}
+  defp via_tuple(instance_id) do
+    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}}}
   end
 
   defp default_options,
@@ -88,8 +87,8 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   defp default_url(_), do: Constants.base_url_global()
 
   @impl ConfigFetcher
-  def fetch(fetcher_id) do
-    fetcher_id
+  def fetch(instance_id) do
+    instance_id
     |> via_tuple()
     |> GenServer.call(:fetch, Constants.fetch_timeout())
   end

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -25,11 +25,10 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   use GenServer
 
   alias ConfigCat.ConfigFetcher
-  alias ConfigCat.Constants
   alias ConfigFetcher.RedirectMode
   alias HTTPoison.Response
 
-  require Constants
+  require ConfigCat.Constants, as: Constants
   require RedirectMode
   require Logger
 

--- a/lib/config_cat/local_file_data_source.ex
+++ b/lib/config_cat/local_file_data_source.ex
@@ -66,10 +66,9 @@ defmodule ConfigCat.LocalFileDataSource do
   end
 
   defimpl OverrideDataSource do
-    alias ConfigCat.Constants
     alias ConfigCat.LocalFileDataSource
 
-    require ConfigCat.Constants
+    require ConfigCat.Constants, as: Constants
 
     @spec behaviour(LocalFileDataSource.t()) :: OverrideDataSource.behaviour()
     def behaviour(data_source), do: data_source.override_behaviour

--- a/lib/config_cat/local_map_data_source.ex
+++ b/lib/config_cat/local_map_data_source.ex
@@ -6,10 +6,9 @@ defmodule ConfigCat.LocalMapDataSource do
   """
 
   alias ConfigCat.Config
-  alias ConfigCat.Constants
   alias ConfigCat.OverrideDataSource
 
-  require ConfigCat.Constants
+  require ConfigCat.Constants, as: Constants
   require Logger
 
   defstruct [:override_behaviour, :settings]

--- a/lib/config_cat/rollout.ex
+++ b/lib/config_cat/rollout.ex
@@ -2,12 +2,11 @@ defmodule ConfigCat.Rollout do
   @moduledoc false
 
   alias ConfigCat.Config
-  alias ConfigCat.Constants
   alias ConfigCat.Rollout.Comparator
   alias ConfigCat.User
 
   require Logger
-  require ConfigCat.Constants
+  require ConfigCat.Constants, as: Constants
 
   @spec evaluate(Config.key(), User.t() | nil, Config.value(), Config.variation_id(), Config.t()) ::
           {Config.value(), Config.variation_id()}

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -26,7 +26,8 @@ defmodule ConfigCat.Supervisor do
       |> generate_cache_key(sdk_key)
 
     name = Keyword.fetch!(options, :name)
-    Supervisor.start_link(__MODULE__, options, name: name)
+
+    Supervisor.start_link(__MODULE__, options, name: :"#{name}.Supervisor")
   end
 
   defp validate_sdk_key(nil), do: raise(ArgumentError, "SDK Key is required")

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -89,9 +89,6 @@ defmodule ConfigCat.Supervisor do
     {CachePolicy, options}
   end
 
-  @spec client_name(atom()) :: atom()
-  def client_name(name), do: :"#{name}.Client"
-
   defp cache_policy_name(name), do: :"#{name}.CachePolicy"
   defp fetcher_name(name), do: :"#{name}.ConfigFetcher"
 
@@ -121,7 +118,6 @@ defmodule ConfigCat.Supervisor do
 
   defp client_options(options) do
     options
-    |> Keyword.update!(:name, &client_name/1)
     |> Keyword.update!(:cache_policy, &CachePolicy.policy_name/1)
     |> Keyword.take([
       :cache_policy,

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -6,12 +6,11 @@ defmodule ConfigCat.Supervisor do
   alias ConfigCat.CacheControlConfigFetcher
   alias ConfigCat.CachePolicy
   alias ConfigCat.Client
-  alias ConfigCat.Constants
   alias ConfigCat.InMemoryCache
   alias ConfigCat.NullDataSource
   alias ConfigCat.OverrideDataSource
 
-  require Constants
+  require ConfigCat.Constants, as: Constants
 
   @default_cache InMemoryCache
 
@@ -92,7 +91,7 @@ defmodule ConfigCat.Supervisor do
       end
 
     cache_key =
-      :crypto.hash(:sha, "#{prefix}_#{ConfigCat.Constants.config_filename()}_#{sdk_key}")
+      :crypto.hash(:sha, "#{prefix}_#{Constants.config_filename()}_#{sdk_key}")
       |> Base.encode16()
 
     Keyword.put(options, :cache_key, cache_key)

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -25,11 +25,11 @@ defmodule ConfigCat.Supervisor do
       |> Keyword.merge(options)
       |> generate_cache_key(sdk_key)
 
-    # Rename name -> id for everything downstream
-    {id, options} = Keyword.pop!(options, :name)
-    options = Keyword.put(options, :id, id)
+    # Rename name -> instance_id for everything downstream
+    {instance_id, options} = Keyword.pop!(options, :name)
+    options = Keyword.put(options, :instance_id, instance_id)
 
-    Supervisor.start_link(__MODULE__, options, name: :"#{id}.Supervisor")
+    Supervisor.start_link(__MODULE__, options, name: :"#{instance_id}.Supervisor")
   end
 
   defp validate_sdk_key(nil), do: raise(ArgumentError, "SDK Key is required")
@@ -103,7 +103,7 @@ defmodule ConfigCat.Supervisor do
   end
 
   defp cache_policy_options(options) do
-    Keyword.take(options, [:cache, :cache_key, :cache_policy, :id, :offline])
+    Keyword.take(options, [:cache, :cache_key, :cache_policy, :instance_id, :offline])
   end
 
   defp client_options(options) do
@@ -113,7 +113,7 @@ defmodule ConfigCat.Supervisor do
       :cache_policy,
       :default_user,
       :flag_overrides,
-      :id
+      :instance_id
     ])
   end
 
@@ -126,7 +126,7 @@ defmodule ConfigCat.Supervisor do
       :connect_timeout_milliseconds,
       :read_timeout_milliseconds,
       :data_governance,
-      :id,
+      :instance_id,
       :mode,
       :sdk_key
     ])

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -118,13 +118,15 @@ defmodule ConfigCat.Supervisor do
 
   defp client_options(options) do
     options
+    |> Keyword.put(:id, options[:name])
+    |> Keyword.delete(:name)
     |> Keyword.update!(:cache_policy, &CachePolicy.policy_name/1)
     |> Keyword.take([
       :cache_policy,
       :cache_policy_id,
       :default_user,
       :flag_overrides,
-      :name
+      :id
     ])
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,8 @@ defmodule ConfigCat.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {ConfigCat.Application, []}
     ]
   end
 

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -19,14 +19,14 @@ defmodule ConfigCat.ConfigFetcherTest do
   @fetcher_options %{mode: @mode, sdk_key: @sdk_key}
 
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options \\ []) do
-    name = UUID.uuid4() |> String.to_atom()
-    default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
+    id = UUID.uuid4() |> String.to_atom()
+    default_options = [api: MockAPI, mode: mode, id: id, sdk_key: sdk_key]
 
-    {:ok, _pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
+    {:ok, pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
 
-    allow(MockAPI, self(), name)
+    allow(MockAPI, self(), pid)
 
-    {:ok, name}
+    {:ok, id}
   end
 
   test "successful fetch" do

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -4,11 +4,10 @@ defmodule ConfigCat.ConfigFetcherTest do
   import Mox
 
   alias ConfigCat.CacheControlConfigFetcher, as: ConfigFetcher
-  alias ConfigCat.Constants
   alias ConfigCat.MockAPI
   alias HTTPoison.Response
 
-  require ConfigCat.{Constants}
+  require ConfigCat.Constants, as: Constants
 
   setup :verify_on_exit!
 

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -19,14 +19,14 @@ defmodule ConfigCat.ConfigFetcherTest do
   @fetcher_options %{mode: @mode, sdk_key: @sdk_key}
 
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options \\ []) do
-    id = UUID.uuid4() |> String.to_atom()
-    default_options = [api: MockAPI, mode: mode, id: id, sdk_key: sdk_key]
+    instance_id = UUID.uuid4() |> String.to_atom()
+    default_options = [api: MockAPI, mode: mode, instance_id: instance_id, sdk_key: sdk_key]
 
     {:ok, pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
 
     allow(MockAPI, self(), pid)
 
-    {:ok, id}
+    {:ok, instance_id}
   end
 
   test "successful fetch" do

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -22,14 +22,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
   @fetcher_options %{mode: @mode, sdk_key: @sdk_key}
 
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options) do
-    id = UUID.uuid4() |> String.to_atom()
-    default_options = [api: MockAPI, id: id, mode: mode, sdk_key: sdk_key]
+    instance_id = UUID.uuid4() |> String.to_atom()
+    default_options = [api: MockAPI, instance_id: instance_id, mode: mode, sdk_key: sdk_key]
 
     {:ok, pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
 
     allow(MockAPI, self(), pid)
 
-    {:ok, id}
+    {:ok, instance_id}
   end
 
   test "test_sdk_global_organization_global" do

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -5,11 +5,10 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
 
   alias ConfigCat.CacheControlConfigFetcher, as: ConfigFetcher
   alias ConfigCat.ConfigFetcher.RedirectMode
-  alias ConfigCat.Constants
   alias ConfigCat.MockAPI
   alias HTTPoison.Response
 
-  require ConfigCat.Constants
+  require ConfigCat.Constants, as: Constants
   require ConfigCat.ConfigFetcher.RedirectMode
 
   setup :verify_on_exit!

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -22,14 +22,14 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
   @fetcher_options %{mode: @mode, sdk_key: @sdk_key}
 
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options) do
-    name = UUID.uuid4() |> String.to_atom()
-    default_options = [api: MockAPI, mode: mode, name: name, sdk_key: sdk_key]
+    id = UUID.uuid4() |> String.to_atom()
+    default_options = [api: MockAPI, id: id, mode: mode, sdk_key: sdk_key]
 
-    {:ok, _pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
+    {:ok, pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})
 
-    allow(MockAPI, self(), name)
+    allow(MockAPI, self(), pid)
 
-    {:ok, name}
+    {:ok, id}
   end
 
   test "test_sdk_global_organization_global" do

--- a/test/config_cat/default_user_test.exs
+++ b/test/config_cat/default_user_test.exs
@@ -1,12 +1,14 @@
 defmodule ConfigCat.DefaultUserTest do
   use ConfigCat.ClientCase, async: true
 
+  import Jason.Sigil
+
   alias ConfigCat.User
 
   @moduletag capture_log: true
 
   setup do
-    config = Jason.decode!(~s(
+    config = ~J"""
       {
         "p": {"u": "https://cdn-global.configcat.com", "r": 0},
         "f": {
@@ -19,7 +21,7 @@ defmodule ConfigCat.DefaultUserTest do
           }
         }
       }
-    ))
+    """
 
     stub_cached_config({:ok, config})
 

--- a/test/config_cat/default_user_test.exs
+++ b/test/config_cat/default_user_test.exs
@@ -1,16 +1,9 @@
 defmodule ConfigCat.DefaultUserTest do
-  use ExUnit.Case, async: true
+  use ConfigCat.ClientCase, async: true
 
-  import Mox
-
-  alias ConfigCat.Client
-  alias ConfigCat.MockCachePolicy
-  alias ConfigCat.NullDataSource
   alias ConfigCat.User
 
   @moduletag capture_log: true
-
-  @cache_policy_id :cache_policy_id
 
   setup do
     config = Jason.decode!(~s(
@@ -28,15 +21,14 @@ defmodule ConfigCat.DefaultUserTest do
       }
     ))
 
-    MockCachePolicy
-    |> stub(:get, fn @cache_policy_id -> {:ok, config} end)
+    stub_cached_config({:ok, config})
 
-    {:ok, config: config}
+    :ok
   end
 
   describe "when the default user is defined in the options" do
     setup do
-      {:ok, client} = start_client(User.new("test@test1.com"))
+      {:ok, client} = start_client(default_user: User.new("test@test1.com"))
       {:ok, client: client}
     end
 
@@ -124,24 +116,5 @@ defmodule ConfigCat.DefaultUserTest do
       actual = ConfigCat.get_all_values(user, client: client) |> Enum.sort()
       assert actual == expected
     end
-  end
-
-  defp start_client(default_user \\ nil) do
-    base_name = UUID.uuid4() |> String.to_atom()
-    name = ConfigCat.Supervisor.client_name(base_name)
-
-    options = [
-      cache_policy: MockCachePolicy,
-      cache_policy_id: @cache_policy_id,
-      default_user: default_user,
-      flag_overrides: NullDataSource.new(),
-      name: name
-    ]
-
-    {:ok, _pid} = start_supervised({Client, options})
-
-    allow(MockCachePolicy, self(), name)
-
-    {:ok, base_name}
   end
 end

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -1,13 +1,14 @@
 defmodule ConfigCatTest do
   use ConfigCat.ClientCase, async: true
 
+  import Jason.Sigil
   import Mox
 
   setup :verify_on_exit!
 
   describe "when the configuration has been fetched" do
     setup do
-      config = Jason.decode!(~s(
+      config = ~J"""
         {
           "p": {"u": "https://cdn-global.configcat.com", "r": 0},
           "f": {
@@ -19,7 +20,7 @@ defmodule ConfigCatTest do
             "key2": {"v": false, "i": "fakeId2","p": [], "r": []}
           }
         }
-      ))
+      """
 
       {:ok, client} = start_client()
 

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -1,40 +1,29 @@
 defmodule ConfigCatTest do
-  use ExUnit.Case, async: true
+  use ConfigCat.ClientCase, async: true
 
   import Mox
 
-  alias ConfigCat.Client
-  alias ConfigCat.MockCachePolicy
-  alias ConfigCat.NullDataSource
-
-  @cache_policy_id :cache_policy_id
-
   setup :verify_on_exit!
 
-  setup do
-    config = Jason.decode!(~s(
-      {
-        "p": {"u": "https://cdn-global.configcat.com", "r": 0},
-        "f": {
-          "testBoolKey": {"v": true,"t": 0, "p": [],"r": []},
-          "testStringKey": {"v": "testValue","t": 1, "p": [],"r": []},
-          "testIntKey": {"v": 1,"t": 2, "p": [],"r": []},
-          "testDoubleKey": {"v": 1.1,"t": 3,"p": [],"r": []},
-          "key1": {"v": true, "i": "fakeId1","p": [], "r": []},
-          "key2": {"v": false, "i": "fakeId2","p": [], "r": []}
-        }
-      }
-    ))
-
-    {:ok, config: config}
-  end
-
   describe "when the configuration has been fetched" do
-    setup %{config: config} do
+    setup do
+      config = Jason.decode!(~s(
+        {
+          "p": {"u": "https://cdn-global.configcat.com", "r": 0},
+          "f": {
+            "testBoolKey": {"v": true,"t": 0, "p": [],"r": []},
+            "testStringKey": {"v": "testValue","t": 1, "p": [],"r": []},
+            "testIntKey": {"v": 1,"t": 2, "p": [],"r": []},
+            "testDoubleKey": {"v": 1.1,"t": 3,"p": [],"r": []},
+            "key1": {"v": true, "i": "fakeId1","p": [], "r": []},
+            "key2": {"v": false, "i": "fakeId2","p": [], "r": []}
+          }
+        }
+      ))
+
       {:ok, client} = start_client()
 
-      MockCachePolicy
-      |> stub(:get, fn @cache_policy_id -> {:ok, config} end)
+      stub_cached_config({:ok, config})
 
       {:ok, client: client}
     end
@@ -111,8 +100,7 @@ defmodule ConfigCatTest do
     setup do
       {:ok, client} = start_client()
 
-      MockCachePolicy
-      |> stub(:get, fn @cache_policy_id -> {:error, :not_found} end)
+      stub_cached_config({:error, :not_found})
 
       {:ok, client: client}
     end
@@ -141,23 +129,5 @@ defmodule ConfigCatTest do
     test "get_all_values/1 returns an empty map", %{client: client} do
       assert ConfigCat.get_all_values(nil, client: client) == %{}
     end
-  end
-
-  defp start_client do
-    base_name = UUID.uuid4() |> String.to_atom()
-    name = ConfigCat.Supervisor.client_name(base_name)
-
-    options = [
-      cache_policy: MockCachePolicy,
-      cache_policy_id: @cache_policy_id,
-      flag_overrides: NullDataSource.new(),
-      name: name
-    ]
-
-    {:ok, _pid} = start_supervised({Client, options})
-
-    allow(MockCachePolicy, self(), name)
-
-    {:ok, base_name}
   end
 end

--- a/test/flag_override_test.exs
+++ b/test/flag_override_test.exs
@@ -1,20 +1,22 @@
 defmodule ConfigCat.FlagOverrideTest do
   use ConfigCat.ClientCase, async: true
 
+  import Jason.Sigil
+
   alias ConfigCat.LocalFileDataSource
   alias ConfigCat.LocalMapDataSource
 
   @moduletag capture_log: true
 
   setup do
-    config = Jason.decode!(~s(
+    config = ~J"""
       {
         "p": {"u": "https://cdn-global.configcat.com", "r": 0},
         "f": {
           "fakeKey": {"v": false, "t": 0, "p": [],"r": []}
         }
       }
-    ))
+    """
 
     stub_cached_config({:ok, config})
 

--- a/test/flag_override_test.exs
+++ b/test/flag_override_test.exs
@@ -1,16 +1,10 @@
 defmodule ConfigCat.FlagOverrideTest do
-  use ExUnit.Case, async: true
+  use ConfigCat.ClientCase, async: true
 
-  import Mox
-
-  alias ConfigCat.Client
   alias ConfigCat.LocalFileDataSource
   alias ConfigCat.LocalMapDataSource
-  alias ConfigCat.MockCachePolicy
 
   @moduletag capture_log: true
-
-  @cache_policy_id :cache_policy_id
 
   setup do
     config = Jason.decode!(~s(
@@ -22,10 +16,9 @@ defmodule ConfigCat.FlagOverrideTest do
       }
     ))
 
-    MockCachePolicy
-    |> stub(:get, fn @cache_policy_id -> {:ok, config} end)
+    stub_cached_config({:ok, config})
 
-    {:ok, config: config}
+    :ok
   end
 
   describe "local-only mode" do
@@ -33,7 +26,7 @@ defmodule ConfigCat.FlagOverrideTest do
       filename = fixture_file("test.json")
       overrides = LocalFileDataSource.new(filename, :local_only)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       assert ConfigCat.get_value("enabledFeature", false, client: client) == true
       assert ConfigCat.get_value("disabledFeature", true, client: client) == false
@@ -46,7 +39,7 @@ defmodule ConfigCat.FlagOverrideTest do
       filename = fixture_file("test_simple.json")
       overrides = LocalFileDataSource.new(filename, :local_only)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       assert ConfigCat.get_value("enabledFeature", false, client: client) == true
       assert ConfigCat.get_value("disabledFeature", true, client: client) == false
@@ -60,7 +53,7 @@ defmodule ConfigCat.FlagOverrideTest do
       filename = temporary_file("simple")
       overrides = LocalFileDataSource.new(filename, :local_only)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       File.open(filename, [:write], fn file ->
         IO.write(file, Jason.encode!(flags))
@@ -86,7 +79,7 @@ defmodule ConfigCat.FlagOverrideTest do
       filename = fixture_file("non_existent.json")
       overrides = LocalFileDataSource.new(filename, :local_only)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       assert ConfigCat.get_value("enabledFeature", false, client: client) == false
     end
@@ -96,7 +89,7 @@ defmodule ConfigCat.FlagOverrideTest do
       filename = temporary_file("invalid.json")
       overrides = LocalFileDataSource.new(filename, :local_only)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       File.open(filename, [:write], fn file ->
         IO.write(file, invalid_contents)
@@ -116,7 +109,7 @@ defmodule ConfigCat.FlagOverrideTest do
 
       overrides = LocalMapDataSource.new(map, :local_only)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       assert ConfigCat.get_value("enabledFeature", false, client: client) == true
       assert ConfigCat.get_value("disabledFeature", true, client: client) == false
@@ -135,7 +128,7 @@ defmodule ConfigCat.FlagOverrideTest do
 
       overrides = LocalMapDataSource.new(map, :local_over_remote)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       assert ConfigCat.get_value("fakeKey", false, client: client) == true
       assert ConfigCat.get_value("nonexisting", false, client: client) == true
@@ -151,7 +144,7 @@ defmodule ConfigCat.FlagOverrideTest do
 
       overrides = LocalMapDataSource.new(map, :remote_over_local)
 
-      {:ok, client} = start_client(overrides)
+      {:ok, client} = start_client(flag_overrides: overrides)
 
       assert ConfigCat.get_value("fakeKey", true, client: client) == false
       assert ConfigCat.get_value("nonexisting", false, client: client) == true
@@ -170,23 +163,5 @@ defmodule ConfigCat.FlagOverrideTest do
     on_exit(fn -> File.rm!(filename) end)
 
     filename
-  end
-
-  defp start_client(flag_overrides) do
-    base_name = UUID.uuid4() |> String.to_atom()
-    name = ConfigCat.Supervisor.client_name(base_name)
-
-    options = [
-      cache_policy: MockCachePolicy,
-      cache_policy_id: @cache_policy_id,
-      flag_overrides: flag_overrides,
-      name: name
-    ]
-
-    {:ok, _pid} = start_supervised({Client, options})
-
-    allow(MockCachePolicy, self(), name)
-
-    {:ok, base_name}
   end
 end

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -24,7 +24,7 @@ defmodule ConfigCat.CachePolicyCase do
 
   @spec start_cache_policy(CachePolicy.t()) :: {:ok, atom()}
   def start_cache_policy(policy) do
-    id = UUID.uuid4() |> String.to_atom()
+    instance_id = UUID.uuid4() |> String.to_atom()
 
     {:ok, cache_key} = start_cache()
 
@@ -36,14 +36,14 @@ defmodule ConfigCat.CachePolicyCase do
            cache_key: cache_key,
            cache_policy: policy,
            fetcher: MockFetcher,
-           id: id,
+           instance_id: instance_id,
            offline: false
          ]}
       )
 
     allow(MockFetcher, self(), pid)
 
-    {:ok, id}
+    {:ok, instance_id}
   end
 
   defp start_cache do

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -24,7 +24,7 @@ defmodule ConfigCat.CachePolicyCase do
 
   @spec start_cache_policy(CachePolicy.t()) :: {:ok, atom()}
   def start_cache_policy(policy) do
-    policy_id = UUID.uuid4() |> String.to_atom()
+    id = UUID.uuid4() |> String.to_atom()
 
     {:ok, cache_key} = start_cache()
 
@@ -36,15 +36,14 @@ defmodule ConfigCat.CachePolicyCase do
            cache_key: cache_key,
            cache_policy: policy,
            fetcher: MockFetcher,
-           id: policy_id,
-           name: policy_id,
+           id: id,
            offline: false
          ]}
       )
 
     allow(MockFetcher, self(), pid)
 
-    {:ok, policy_id}
+    {:ok, id}
   end
 
   defp start_cache do

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -17,14 +17,14 @@ defmodule ConfigCat.ClientCase do
 
   @spec start_client([Client.option()]) :: {:ok, GenServer.server()}
   def start_client(opts \\ []) do
-    name = UUID.uuid4() |> String.to_atom()
+    id = UUID.uuid4() |> String.to_atom()
 
     options =
       [
         cache_policy: MockCachePolicy,
         cache_policy_id: @cache_policy_id,
         flag_overrides: NullDataSource.new(),
-        name: name
+        id: id
       ]
       |> Keyword.merge(opts)
 
@@ -32,7 +32,7 @@ defmodule ConfigCat.ClientCase do
 
     Mox.allow(MockCachePolicy, self(), pid)
 
-    {:ok, name}
+    {:ok, id}
   end
 
   @spec stub_cached_config({:ok, Config.t()} | {:error, :not_found}) :: :ok

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -1,0 +1,46 @@
+defmodule ConfigCat.ClientCase do
+  @moduledoc false
+
+  use ExUnit.CaseTemplate
+
+  alias ConfigCat.Client
+  alias ConfigCat.MockCachePolicy
+  alias ConfigCat.NullDataSource
+
+  using do
+    quote do
+      import unquote(__MODULE__)
+    end
+  end
+
+  @cache_policy_id :cache_policy_id
+
+  @spec start_client([Client.option()]) :: {:ok, GenServer.server()}
+  def start_client(opts \\ []) do
+    base_name = UUID.uuid4() |> String.to_atom()
+    name = ConfigCat.Supervisor.client_name(base_name)
+
+    options =
+      [
+        cache_policy: MockCachePolicy,
+        cache_policy_id: @cache_policy_id,
+        flag_overrides: NullDataSource.new(),
+        name: name
+      ]
+      |> Keyword.merge(opts)
+
+    {:ok, pid} = start_supervised({Client, options})
+
+    Mox.allow(MockCachePolicy, self(), pid)
+
+    {:ok, base_name}
+  end
+
+  @spec stub_cached_config({:ok, Config.t()} | {:error, :not_found}) :: :ok
+  def stub_cached_config(response) do
+    MockCachePolicy
+    |> Mox.stub(:get, fn @cache_policy_id -> response end)
+
+    :ok
+  end
+end

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -13,8 +13,6 @@ defmodule ConfigCat.ClientCase do
     end
   end
 
-  @cache_policy_id :cache_policy_id
-
   @spec start_client([Client.option()]) :: {:ok, GenServer.server()}
   def start_client(opts \\ []) do
     id = UUID.uuid4() |> String.to_atom()
@@ -22,7 +20,6 @@ defmodule ConfigCat.ClientCase do
     options =
       [
         cache_policy: MockCachePolicy,
-        cache_policy_id: @cache_policy_id,
         flag_overrides: NullDataSource.new(),
         id: id
       ]
@@ -38,7 +35,7 @@ defmodule ConfigCat.ClientCase do
   @spec stub_cached_config({:ok, Config.t()} | {:error, :not_found}) :: :ok
   def stub_cached_config(response) do
     MockCachePolicy
-    |> Mox.stub(:get, fn @cache_policy_id -> response end)
+    |> Mox.stub(:get, fn _id -> response end)
 
     :ok
   end

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -15,13 +15,13 @@ defmodule ConfigCat.ClientCase do
 
   @spec start_client([Client.option()]) :: {:ok, GenServer.server()}
   def start_client(opts \\ []) do
-    id = UUID.uuid4() |> String.to_atom()
+    instance_id = UUID.uuid4() |> String.to_atom()
 
     options =
       [
         cache_policy: MockCachePolicy,
         flag_overrides: NullDataSource.new(),
-        id: id
+        instance_id: instance_id
       ]
       |> Keyword.merge(opts)
 
@@ -29,7 +29,7 @@ defmodule ConfigCat.ClientCase do
 
     Mox.allow(MockCachePolicy, self(), pid)
 
-    {:ok, id}
+    {:ok, instance_id}
   end
 
   @spec stub_cached_config({:ok, Config.t()} | {:error, :not_found}) :: :ok

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -17,8 +17,7 @@ defmodule ConfigCat.ClientCase do
 
   @spec start_client([Client.option()]) :: {:ok, GenServer.server()}
   def start_client(opts \\ []) do
-    base_name = UUID.uuid4() |> String.to_atom()
-    name = ConfigCat.Supervisor.client_name(base_name)
+    name = UUID.uuid4() |> String.to_atom()
 
     options =
       [
@@ -33,7 +32,7 @@ defmodule ConfigCat.ClientCase do
 
     Mox.allow(MockCachePolicy, self(), pid)
 
-    {:ok, base_name}
+    {:ok, name}
   end
 
   @spec stub_cached_config({:ok, Config.t()} | {:error, :not_found}) :: :ok


### PR DESCRIPTION
### Describe the purpose of your pull request

This is a purely internal (non-user-facing) refactoring that replaces the use of constructed GenServer names with a [Registry](https://hexdocs.pm/elixir/1.15.2/Registry.html), which is a more standard Elixir way of doing things.

Introduces an `Application` module that starts a single `Registry` that is shared by all of the ConfigCat instances started by the end-user's code. This Registry is also started in the test environment by default, allowing us to make use of it in all of our tests without having to change code or do anything strange.

The `name` that a user might pass in to identify a particular ConfigCat instance becomes the `instance_id` that all related processes use to find each other, using [`:via` tuples](https://hexdocs.pm/elixir/1.15.2/Registry.html#module-using-in-via).

Other changes/cleanups:
- Extract duplication from several test suites into a new `ClientCase` case template.
- Extract duplication from the various CachePolicy modules into a `__using__` block in `CachePolicy.Behaviour`. This should make our life easier when we need to add new functions to all of the cache policies.
- Rename the `Supervisor` to have a `.Supervisor` suffix for greater clarity when debugging.
- Use `Jason.Sigil` (`~J`) to simplify hard-coded JSON strings in tests.
- Use `require ..., as:` syntax to simplify the use of the `Constants` module.

### Related issues (only if applicable)

None

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
