### PR TITLE
♻️ Use the latest fetch time for lazy load and auto-poll

### DIFF
--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -44,10 +44,15 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
   @spec cached_config(state()) :: ConfigCache.result()
   def cached_config(state) do
-    with instance_id <- Map.fetch!(state, :instance_id),
-         {:ok, entry} <- Cache.get(instance_id) do
+    with {:ok, %ConfigEntry{} = entry} <- cached_entry(state) do
       {:ok, entry.config}
     end
+  end
+
+  @spec cached_entry(state()) :: {:ok, ConfigEntry.t()} | {:error, :not_found}
+  def cached_entry(state) do
+    instance_id = Map.fetch!(state, :instance_id)
+    Cache.get(instance_id)
   end
 
   @spec refresh_config(state()) :: CachePolicy.refresh_result()

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -16,17 +16,17 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       seconds = 123
       policy = CachePolicy.auto(poll_interval_seconds: seconds)
 
-      assert policy == %Auto{poll_interval_seconds: seconds, mode: "a"}
+      assert policy == %Auto{poll_interval_ms: seconds * 1000, mode: "a"}
     end
 
     test "provides a default poll interval" do
       policy = CachePolicy.auto()
-      assert policy.poll_interval_seconds == 60
+      assert policy.poll_interval_ms == 60_000
     end
 
     test "enforces a minimum poll interval" do
       policy = CachePolicy.auto(poll_interval_seconds: -1)
-      assert policy.poll_interval_seconds == 1
+      assert policy.poll_interval_ms == 1000
     end
 
     test "does not have a change callback by default" do
@@ -212,7 +212,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
   end
 
   defp wait_for_poll(policy) do
-    (policy.poll_interval_seconds * 1000 + 50)
+    (policy.poll_interval_ms + 50)
     |> Process.sleep()
   end
 end

--- a/test/config_cat/cache_policy/lazy_test.exs
+++ b/test/config_cat/cache_policy/lazy_test.exs
@@ -15,97 +15,97 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       seconds = 123
       policy = CachePolicy.lazy(cache_expiry_seconds: seconds)
 
-      assert policy == %Lazy{cache_expiry_seconds: seconds, mode: "l"}
+      assert policy == %Lazy{cache_expiry_ms: seconds * 1000, mode: "l"}
     end
   end
 
   describe "getting the config" do
     test "fetches config when first requested", %{config: config} do
-      {:ok, policy_id} = start_cache_policy(@policy)
+      {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(config)
 
-      assert {:ok, ^config} = Lazy.get(policy_id)
+      assert {:ok, ^config} = Lazy.get(instance_id)
     end
 
     test "doesn't re-fetch if cache has not expired", %{config: config} do
-      {:ok, policy_id} = start_cache_policy(@policy)
+      {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(config)
-      Lazy.force_refresh(policy_id)
+      Lazy.force_refresh(instance_id)
 
       expect_not_refreshed()
-      Lazy.get(policy_id)
+      Lazy.get(instance_id)
     end
 
     test "re-fetches if cache has expired", %{config: config} do
       policy = CachePolicy.lazy(cache_expiry_seconds: 0)
-      {:ok, policy_id} = start_cache_policy(policy)
+      {:ok, instance_id} = start_cache_policy(policy)
       old_config = %{"old" => "config"}
 
       expect_refresh(old_config)
-      Lazy.force_refresh(policy_id)
+      Lazy.force_refresh(instance_id)
 
       expect_refresh(config)
-      assert {:ok, ^config} = Lazy.get(policy_id)
+      assert {:ok, ^config} = Lazy.get(instance_id)
     end
   end
 
   describe "refreshing the config" do
     test "stores new config in the cache", %{config: config} do
-      {:ok, policy_id} = start_cache_policy(@policy)
+      {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(config)
 
-      assert :ok = Lazy.force_refresh(policy_id)
-      assert {:ok, ^config} = Lazy.get(policy_id)
+      assert :ok = Lazy.force_refresh(instance_id)
+      assert {:ok, ^config} = Lazy.get(instance_id)
     end
 
     test "fetches new config even if cache is not expired", %{config: config} do
-      {:ok, policy_id} = start_cache_policy(@policy)
+      {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(config)
-      Lazy.force_refresh(policy_id)
+      Lazy.force_refresh(instance_id)
 
       expect_refresh(config)
-      Lazy.force_refresh(policy_id)
+      Lazy.force_refresh(instance_id)
     end
 
     test "does not update config when server responds that the config hasn't changed" do
-      {:ok, policy_id} = start_cache_policy(@policy)
+      {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_unchanged()
 
-      assert :ok = Lazy.force_refresh(policy_id)
+      assert :ok = Lazy.force_refresh(instance_id)
     end
 
     @tag capture_log: true
     test "handles error responses" do
-      {:ok, policy_id} = start_cache_policy(@policy)
+      {:ok, instance_id} = start_cache_policy(@policy)
 
-      assert_returns_error(fn -> Lazy.force_refresh(policy_id) end)
+      assert_returns_error(fn -> Lazy.force_refresh(instance_id) end)
     end
   end
 
   describe "offline" do
     test "does not fetch config when offline mode is set", %{config: config} do
-      {:ok, policy_id} = start_cache_policy(@policy)
-      assert Lazy.is_offline(policy_id) == false
+      {:ok, instance_id} = start_cache_policy(@policy)
+      assert Lazy.is_offline(instance_id) == false
 
       expect_refresh(config)
-      assert :ok = Lazy.force_refresh(policy_id)
+      assert :ok = Lazy.force_refresh(instance_id)
 
-      assert :ok = Lazy.set_offline(policy_id)
-      assert Lazy.is_offline(policy_id) == true
+      assert :ok = Lazy.set_offline(instance_id)
+      assert Lazy.is_offline(instance_id) == true
 
       expect_not_refreshed()
-      assert :ok = Lazy.force_refresh(policy_id)
+      assert :ok = Lazy.force_refresh(instance_id)
 
-      assert :ok = Lazy.set_online(policy_id)
-      assert Lazy.is_offline(policy_id) == false
+      assert :ok = Lazy.set_online(instance_id)
+      assert Lazy.is_offline(instance_id) == false
 
       expect_refresh(config)
-      assert :ok = Lazy.force_refresh(policy_id)
+      assert :ok = Lazy.force_refresh(instance_id)
     end
   end
 end


### PR DESCRIPTION
### Describe the purpose of your pull request

- Use the latest ConfigEntry's fetch time when determining whether to refetch in lazy mode. This replaces the latest fetch time that was stored in state.
- Use the fetch time to calculate the time until the first auto-polling fetch after starting up and after coming back online. If the cache entry is more than `poll_interval_seconds` old, fetch immediately. Otherwise, wait until `poll_interval_seconds` after the previous fetch.

**NOTE:** This PR is built on top of #89 and I've set the base branch accordingly for easier review. I'll rebase this PR once that one has been merged.

### Related issues (only if applicable)

https://trello.com/c/eekAiFY3/6-lazyload-ttl-autopoll-interval-should-be-stored-in-cache-elixir

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
