### PR TITLE
♻️ Start a single InMemoryCache for all instances

### DIFF
--- a/lib/config_cat/application.ex
+++ b/lib/config_cat/application.ex
@@ -3,9 +3,11 @@ defmodule ConfigCat.Application do
 
   use Application
 
+  alias ConfigCat.InMemoryCache
+
   @impl Application
   def start(_type, _args) do
-    children = [{Registry, keys: :unique, name: ConfigCat.Registry}]
+    children = [{Registry, keys: :unique, name: ConfigCat.Registry}, InMemoryCache]
 
     opts = [strategy: :one_for_one, name: ConfigCat.RegistrySupervisor]
     Supervisor.start_link(children, opts)

--- a/lib/config_cat/in_memory_cache.ex
+++ b/lib/config_cat/in_memory_cache.ex
@@ -5,33 +5,26 @@ defmodule ConfigCat.InMemoryCache do
 
   alias ConfigCat.ConfigCache
 
-  @type option :: {:cache_key, ConfigCache.key()}
-  @type options :: [option]
-
   @behaviour ConfigCache
 
-  @spec start_link(options()) :: GenServer.on_start()
-  def start_link(options) do
-    name =
-      options
-      |> Keyword.fetch!(:cache_key)
-      |> name_from_cache_key()
-
-    GenServer.start_link(__MODULE__, :empty, name: name)
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_options) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
   @impl ConfigCache
   def get(cache_key) do
-    GenServer.call(name_from_cache_key(cache_key), :get)
+    GenServer.call(__MODULE__, {:get, cache_key})
   end
 
   @impl ConfigCache
   def set(cache_key, value) do
-    GenServer.call(name_from_cache_key(cache_key), {:set, value})
+    GenServer.call(__MODULE__, {:set, cache_key, value})
   end
 
-  defp name_from_cache_key(cache_key) do
-    String.to_atom(cache_key)
+  @spec clear :: :ok
+  def clear do
+    GenServer.call(__MODULE__, :clear)
   end
 
   @impl GenServer
@@ -40,17 +33,23 @@ defmodule ConfigCat.InMemoryCache do
   end
 
   @impl GenServer
-  def handle_call(:get, _from, :empty = state) do
-    {:reply, {:error, :not_found}, state}
+  def handle_call(:clear, _from, state) do
+    {:reply, :ok, %{}}
   end
 
   @impl GenServer
-  def handle_call(:get, _from, state) do
-    {:reply, {:ok, state}, state}
+  def handle_call({:get, cache_key}, _from, state) do
+    result =
+      case Map.get(state, cache_key) do
+        nil -> {:error, :not_found}
+        value -> {:ok, value}
+      end
+
+    {:reply, result, state}
   end
 
   @impl GenServer
-  def handle_call({:set, value}, _from, _state) do
-    {:reply, :ok, value}
+  def handle_call({:set, cache_key, value}, _from, state) do
+    {:reply, :ok, Map.put(state, cache_key, value)}
   end
 end

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -53,7 +53,6 @@ defmodule ConfigCat.Supervisor do
 
     children =
       [
-        default_cache(options),
         cache(options),
         config_fetcher(options, override_behaviour),
         cache_policy(options, override_behaviour),
@@ -62,13 +61,6 @@ defmodule ConfigCat.Supervisor do
       |> Enum.reject(&is_nil/1)
 
     Supervisor.init(children, strategy: :one_for_one)
-  end
-
-  defp default_cache(options) do
-    case Keyword.get(options, :cache) do
-      @default_cache -> {@default_cache, Keyword.take(options, [:cache_key])}
-      _ -> nil
-    end
   end
 
   defp cache(options) do

--- a/test/config_cat/in_memory_cache_test.exs
+++ b/test/config_cat/in_memory_cache_test.exs
@@ -6,7 +6,7 @@ defmodule ConfigCat.InMemoryCacheTest do
   @cache_key "CACHE_KEY"
 
   setup do
-    {:ok, _pid} = start_supervised({Cache, [cache_key: @cache_key]})
+    Cache.clear()
 
     :ok
   end
@@ -21,5 +21,14 @@ defmodule ConfigCat.InMemoryCacheTest do
     :ok = Cache.set(@cache_key, entry)
 
     assert {:ok, ^entry} = Cache.get(@cache_key)
+  end
+
+  test "cache is empty after clearing" do
+    entry = "serialized-cache-entry"
+
+    :ok = Cache.set(@cache_key, entry)
+
+    assert :ok = Cache.clear()
+    assert Cache.get(@cache_key) == {:error, :not_found}
   end
 end

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -2,6 +2,7 @@ defmodule ConfigCat.IntegrationTest do
   use ExUnit.Case, async: true
 
   alias ConfigCat.CachePolicy
+  alias ConfigCat.InMemoryCache
 
   @sdk_key "PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA"
 
@@ -106,6 +107,8 @@ defmodule ConfigCat.IntegrationTest do
   end
 
   defp start_config_cat(sdk_key, options \\ []) do
+    InMemoryCache.clear()
+
     name = UUID.uuid4() |> String.to_atom()
     default_options = [name: name, sdk_key: sdk_key]
 

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -50,8 +50,7 @@ defmodule ConfigCat.CachePolicyCase do
 
   defp start_cache(instance_id) do
     cache_key = UUID.uuid4()
-
-    {:ok, _pid} = start_supervised({InMemoryCache, [cache_key: cache_key]})
+    InMemoryCache.clear()
 
     {:ok, _pid} =
       start_supervised(


### PR DESCRIPTION
### Describe the purpose of your pull request

Refactor: Rather than starting up separate cache processes that each store a single cache entry for each ConfigCat instance, start a single one that can be shared by all instances.

**NOTE:** This PR is built on top of #91 and I've set the base branch accordingly. Once that PR is merged (or rejected), I'll rebase this PR before merging.

### Related issues (only if applicable)

None

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
