### PR TITLE
♻️ Make CachePolicy a facade to the actual policy

### DIFF
--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -2,7 +2,6 @@ defmodule ConfigCat.CachePolicy.Behaviour do
   @moduledoc false
 
   alias ConfigCat.CachePolicy
-  alias ConfigCat.CachePolicy.Behaviour
   alias ConfigCat.CachePolicy.Helpers
   alias ConfigCat.Config
 
@@ -16,52 +15,9 @@ defmodule ConfigCat.CachePolicy.Behaviour do
 
   defmacro __using__(_opts) do
     quote location: :keep do
-      require ConfigCat.Constants, as: Constants
-
-      @behaviour Behaviour
-
       @spec start_link(CachePolicy.options()) :: GenServer.on_start()
       def start_link(options) do
         Helpers.start_link(__MODULE__, options)
-      end
-
-      @impl Behaviour
-      def get(instance_id) do
-        instance_id
-        |> via_tuple()
-        |> GenServer.call(:get, Constants.fetch_timeout())
-      end
-
-      @impl Behaviour
-      def is_offline(instance_id) do
-        instance_id
-        |> via_tuple()
-        |> GenServer.call(:is_offline, Constants.fetch_timeout())
-      end
-
-      @impl Behaviour
-      def set_offline(instance_id) do
-        instance_id
-        |> via_tuple()
-        |> GenServer.call(:set_offline, Constants.fetch_timeout())
-      end
-
-      @impl Behaviour
-      def set_online(instance_id) do
-        instance_id
-        |> via_tuple()
-        |> GenServer.call(:set_online, Constants.fetch_timeout())
-      end
-
-      @impl Behaviour
-      def force_refresh(instance_id) do
-        instance_id
-        |> via_tuple()
-        |> GenServer.call(:force_refresh, Constants.fetch_timeout())
-      end
-
-      defp via_tuple(instance_id) do
-        Helpers.via_tuple(__MODULE__, instance_id)
       end
     end
   end

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -48,12 +48,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
   def start_link(module, options) do
     instance_id = Keyword.fetch!(options, :instance_id)
 
-    GenServer.start_link(module, State.new(options), name: via_tuple(module, instance_id))
-  end
-
-  @spec via_tuple(module(), ConfigCat.instance_id()) :: {:via, module(), term()}
-  def via_tuple(module, instance_id) do
-    {:via, Registry, {ConfigCat.Registry, {module, instance_id}}}
+    GenServer.start_link(module, State.new(options), name: CachePolicy.via_tuple(instance_id))
   end
 
   @spec cached_config(State.t()) :: ConfigCache.result()

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -24,6 +24,7 @@ defmodule ConfigCat.Client do
 
     @spec new(keyword()) :: t()
     def new(options) do
+      options = Keyword.merge([cache_policy: CachePolicy], options)
       struct!(__MODULE__, options)
     end
 

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -99,9 +99,7 @@ defmodule ConfigCat.Supervisor do
   defp client(options) do
     client_options =
       options
-      |> Keyword.update!(:cache_policy, &CachePolicy.policy_name/1)
       |> Keyword.take([
-        :cache_policy,
         :default_user,
         :flag_overrides,
         :instance_id

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -47,7 +47,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
 
       {:ok, policy_id} = start_cache_policy(@policy)
 
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
     end
 
     test "doesn't refresh between poll intervals", %{config: config} do
@@ -55,7 +55,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       {:ok, policy_id} = start_cache_policy(@policy)
 
       expect_not_refreshed()
-      Auto.get(policy_id)
+      CachePolicy.get(policy_id)
     end
 
     test "refreshes automatically after poll interval", %{config: config} do
@@ -69,7 +69,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       expect_refresh(config)
       wait_for_poll(policy)
 
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
     end
 
     test "calls the change callback after refreshing", %{config: config} do
@@ -124,11 +124,11 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       expect_refresh(old_config)
 
       {:ok, policy_id} = start_cache_policy(@policy)
-      assert {:ok, ^old_config} = Auto.get(policy_id)
+      assert {:ok, ^old_config} = CachePolicy.get(policy_id)
 
       expect_refresh(config)
-      assert :ok = Auto.force_refresh(policy_id)
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
     end
 
     test "calls the change callback", %{config: config} do
@@ -142,7 +142,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       assert_receive(:callback)
 
       expect_refresh(config)
-      :ok = Auto.force_refresh(policy_id)
+      :ok = CachePolicy.force_refresh(policy_id)
 
       assert_receive(:callback)
     end
@@ -160,7 +160,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       policy = CachePolicy.auto(on_changed: callback)
       {:ok, policy_id} = start_cache_policy(policy)
 
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
       assert_receive(:callback)
     end
 
@@ -172,7 +172,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
 
       expect_unchanged()
 
-      assert :ok = Auto.force_refresh(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
     end
 
     @tag capture_log: true
@@ -180,7 +180,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       expect_refresh(config)
       {:ok, policy_id} = start_cache_policy(@policy)
 
-      assert_returns_error(fn -> Auto.force_refresh(policy_id) end)
+      assert_returns_error(fn -> CachePolicy.force_refresh(policy_id) end)
     end
   end
 
@@ -189,25 +189,25 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       expect_refresh(config)
       policy = CachePolicy.auto(poll_interval_seconds: 1)
       {:ok, policy_id} = start_cache_policy(policy)
-      assert Auto.is_offline(policy_id) == false
+      assert CachePolicy.is_offline(policy_id) == false
 
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
 
-      assert :ok = Auto.set_offline(policy_id)
-      assert Auto.is_offline(policy_id) == true
+      assert :ok = CachePolicy.set_offline(policy_id)
+      assert CachePolicy.is_offline(policy_id) == true
 
       expect_not_refreshed()
       wait_for_poll(policy)
 
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
 
-      assert :ok = Auto.set_online(policy_id)
-      assert Auto.is_offline(policy_id) == false
+      assert :ok = CachePolicy.set_online(policy_id)
+      assert CachePolicy.is_offline(policy_id) == false
 
       expect_refresh(config)
       wait_for_poll(policy)
 
-      assert {:ok, ^config} = Auto.get(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
     end
   end
 

--- a/test/config_cat/cache_policy/lazy_test.exs
+++ b/test/config_cat/cache_policy/lazy_test.exs
@@ -25,17 +25,17 @@ defmodule ConfigCat.CachePolicy.LazyTest do
 
       expect_refresh(config)
 
-      assert {:ok, ^config} = Lazy.get(instance_id)
+      assert {:ok, ^config} = CachePolicy.get(instance_id)
     end
 
     test "doesn't re-fetch if cache has not expired", %{config: config} do
       {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(config)
-      Lazy.force_refresh(instance_id)
+      CachePolicy.force_refresh(instance_id)
 
       expect_not_refreshed()
-      Lazy.get(instance_id)
+      CachePolicy.get(instance_id)
     end
 
     test "re-fetches if cache has expired", %{config: config} do
@@ -44,10 +44,10 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       old_config = %{"old" => "config"}
 
       expect_refresh(old_config)
-      Lazy.force_refresh(instance_id)
+      CachePolicy.force_refresh(instance_id)
 
       expect_refresh(config)
-      assert {:ok, ^config} = Lazy.get(instance_id)
+      assert {:ok, ^config} = CachePolicy.get(instance_id)
     end
   end
 
@@ -57,18 +57,18 @@ defmodule ConfigCat.CachePolicy.LazyTest do
 
       expect_refresh(config)
 
-      assert :ok = Lazy.force_refresh(instance_id)
-      assert {:ok, ^config} = Lazy.get(instance_id)
+      assert :ok = CachePolicy.force_refresh(instance_id)
+      assert {:ok, ^config} = CachePolicy.get(instance_id)
     end
 
     test "fetches new config even if cache is not expired", %{config: config} do
       {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(config)
-      Lazy.force_refresh(instance_id)
+      CachePolicy.force_refresh(instance_id)
 
       expect_refresh(config)
-      Lazy.force_refresh(instance_id)
+      CachePolicy.force_refresh(instance_id)
     end
 
     test "does not update config when server responds that the config hasn't changed" do
@@ -76,36 +76,36 @@ defmodule ConfigCat.CachePolicy.LazyTest do
 
       expect_unchanged()
 
-      assert :ok = Lazy.force_refresh(instance_id)
+      assert :ok = CachePolicy.force_refresh(instance_id)
     end
 
     @tag capture_log: true
     test "handles error responses" do
       {:ok, instance_id} = start_cache_policy(@policy)
 
-      assert_returns_error(fn -> Lazy.force_refresh(instance_id) end)
+      assert_returns_error(fn -> CachePolicy.force_refresh(instance_id) end)
     end
   end
 
   describe "offline" do
     test "does not fetch config when offline mode is set", %{config: config} do
       {:ok, instance_id} = start_cache_policy(@policy)
-      assert Lazy.is_offline(instance_id) == false
+      assert CachePolicy.is_offline(instance_id) == false
 
       expect_refresh(config)
-      assert :ok = Lazy.force_refresh(instance_id)
+      assert :ok = CachePolicy.force_refresh(instance_id)
 
-      assert :ok = Lazy.set_offline(instance_id)
-      assert Lazy.is_offline(instance_id) == true
+      assert :ok = CachePolicy.set_offline(instance_id)
+      assert CachePolicy.is_offline(instance_id) == true
 
       expect_not_refreshed()
-      assert :ok = Lazy.force_refresh(instance_id)
+      assert :ok = CachePolicy.force_refresh(instance_id)
 
-      assert :ok = Lazy.set_online(instance_id)
-      assert Lazy.is_offline(instance_id) == false
+      assert :ok = CachePolicy.set_online(instance_id)
+      assert CachePolicy.is_offline(instance_id) == false
 
       expect_refresh(config)
-      assert :ok = Lazy.force_refresh(instance_id)
+      assert :ok = CachePolicy.force_refresh(instance_id)
     end
   end
 end

--- a/test/config_cat/cache_policy/manual_test.exs
+++ b/test/config_cat/cache_policy/manual_test.exs
@@ -24,7 +24,7 @@ defmodule ConfigCat.CachePolicy.ManualTest do
 
       expect_not_refreshed()
 
-      assert {:error, :not_found} = Manual.get(policy_id)
+      assert {:error, :not_found} = CachePolicy.get(policy_id)
     end
   end
 
@@ -34,8 +34,8 @@ defmodule ConfigCat.CachePolicy.ManualTest do
 
       expect_refresh(config)
 
-      assert :ok = Manual.force_refresh(policy_id)
-      assert {:ok, ^config} = Manual.get(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
+      assert {:ok, ^config} = CachePolicy.get(policy_id)
     end
 
     test "does not update config when server responds that the config hasn't changed" do
@@ -43,14 +43,14 @@ defmodule ConfigCat.CachePolicy.ManualTest do
 
       expect_unchanged()
 
-      assert :ok = Manual.force_refresh(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
     end
 
     @tag capture_log: true
     test "handles error responses" do
       {:ok, policy_id} = start_cache_policy(@policy)
 
-      assert_returns_error(fn -> Manual.force_refresh(policy_id) end)
+      assert_returns_error(fn -> CachePolicy.force_refresh(policy_id) end)
     end
   end
 
@@ -58,22 +58,22 @@ defmodule ConfigCat.CachePolicy.ManualTest do
     @tag capture_log: true
     test "does not fetch config when offline mode is set", %{config: config} do
       {:ok, policy_id} = start_cache_policy(@policy)
-      assert Manual.is_offline(policy_id) == false
+      assert CachePolicy.is_offline(policy_id) == false
 
       expect_refresh(config)
-      assert :ok = Manual.force_refresh(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
 
-      assert :ok = Manual.set_offline(policy_id)
-      assert Manual.is_offline(policy_id) == true
+      assert :ok = CachePolicy.set_offline(policy_id)
+      assert CachePolicy.is_offline(policy_id) == true
 
       expect_not_refreshed()
-      assert :ok = Manual.force_refresh(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
 
-      assert :ok = Manual.set_online(policy_id)
-      assert Manual.is_offline(policy_id) == false
+      assert :ok = CachePolicy.set_online(policy_id)
+      assert CachePolicy.is_offline(policy_id) == false
 
       expect_refresh(config)
-      assert :ok = Manual.force_refresh(policy_id)
+      assert :ok = CachePolicy.force_refresh(policy_id)
     end
   end
 end


### PR DESCRIPTION

### Describe the purpose of your pull request

Refactor: All calls to the running cache policy now go through CachePolicy itself, which then sends messages to the running GenServer.

We still need to allow a `cache_policy` option in Client to allow for injection of a mock cache policy, but we no longer need to specify the cache policy option from the Supervisor.

**NOTE:** This PR is built on top of #92 and I've set the base branch accordingly. Once that PR is merged (or rejected), I'll rebase this PR before merging.

### Related issues (only if applicable)

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
