### PR TITLE
♻️ Use ETag from cache instead of fetcher state

### DIFF
--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -65,7 +65,13 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
   @spec refresh_config(State.t()) :: CachePolicy.refresh_result()
   def refresh_config(%State{} = state) do
-    case state.fetcher.fetch(state.instance_id) do
+    etag =
+      case cached_entry(state) do
+        {:ok, %ConfigEntry{} = entry} -> entry.etag
+        _ -> nil
+      end
+
+    case state.fetcher.fetch(state.instance_id, etag) do
       {:ok, :unchanged} ->
         :ok
 

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -48,7 +48,7 @@ defmodule ConfigCat.ConfigFetcherTest do
               etag: @etag,
               fetch_time_ms: fetch_time_ms,
               raw_config: @raw_config
-            }} = ConfigFetcher.fetch(fetcher)
+            }} = ConfigFetcher.fetch(fetcher, nil)
 
     assert before <= fetch_time_ms && fetch_time_ms <= ConfigEntry.now()
   end
@@ -65,7 +65,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, response}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "sends proper cache control header on later requests" do
@@ -83,7 +83,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, initial_response}
     end)
 
-    {:ok, _} = ConfigFetcher.fetch(fetcher)
+    {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
 
     not_modified_response = %Response{
       status_code: 304,
@@ -96,7 +96,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, not_modified_response}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, @etag)
   end
 
   test "returns unchanged response when server responds that the config hasn't changed" do
@@ -110,7 +110,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     MockAPI
     |> stub(:get, fn _url, _headers, _options -> {:ok, response} end)
 
-    assert {:ok, :unchanged} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, :unchanged} = ConfigFetcher.fetch(fetcher, @etag)
   end
 
   @tag capture_log: true
@@ -122,7 +122,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     MockAPI
     |> stub(:get, fn _url, _headers, _options -> {:ok, response} end)
 
-    assert {:error, ^response} = ConfigFetcher.fetch(fetcher)
+    assert {:error, ^response} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   @tag capture_log: true
@@ -134,7 +134,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     MockAPI
     |> stub(:get, fn _url, _headers, _options -> {:error, error} end)
 
-    assert {:error, ^error} = ConfigFetcher.fetch(fetcher)
+    assert {:error, ^error} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "allows base URL to be configured" do
@@ -149,7 +149,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, %Response{status_code: 200, body: @raw_config}}
     end)
 
-    {:ok, _} = ConfigFetcher.fetch(fetcher)
+    {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "uses default timeouts if none provided" do
@@ -164,7 +164,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, response}
     end)
 
-    {:ok, _} = ConfigFetcher.fetch(fetcher)
+    {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "uses specified timeouts when provided" do
@@ -186,7 +186,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, response}
     end)
 
-    {:ok, _} = ConfigFetcher.fetch(fetcher)
+    {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "sends http proxy options when provided" do
@@ -201,7 +201,7 @@ defmodule ConfigCat.ConfigFetcherTest do
       {:ok, response}
     end)
 
-    {:ok, _} = ConfigFetcher.fetch(fetcher)
+    {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   defp global_config_url(sdk_key \\ @sdk_key) do

--- a/test/config_cat/data_governance_test.exs
+++ b/test/config_cat/data_governance_test.exs
@@ -53,8 +53,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: raw_config}}
     end)
 
-    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_eu_organization_global" do
@@ -78,8 +78,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: raw_config}}
     end)
 
-    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, %ConfigEntry{config: ^config}} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_global_organization_eu_only" do
@@ -99,8 +99,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: config_eu}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_eu_organization_eu_only" do
@@ -120,8 +120,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: config_eu}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_global_custom_base_url" do
@@ -148,8 +148,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: %{}}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_eu_custom_base_url" do
@@ -176,8 +176,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: %{}}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_global_forced" do
@@ -200,8 +200,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       :not_called
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_base_url_forced" do
@@ -232,8 +232,8 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: config_to_forced}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "test_sdk_redirect_loop" do
@@ -253,7 +253,7 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: config_to_global}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
 
     MockAPI
     |> expect(:get, 1, fn ^eu_url, _headers, _options ->
@@ -263,7 +263,7 @@ defmodule ConfigCat.ConfigFetcher.DataGovernanceTest do
       {:ok, %Response{status_code: 200, body: config_to_eu}}
     end)
 
-    assert {:ok, _} = ConfigFetcher.fetch(fetcher)
+    assert {:ok, _} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   defp stub_response(response_uri, redirect) do

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -63,19 +63,19 @@ defmodule ConfigCat.CachePolicyCase do
   @spec expect_refresh(Config.t()) :: Mox.t()
   def expect_refresh(config) do
     MockFetcher
-    |> expect(:fetch, fn _id -> {:ok, ConfigEntry.new(config, "ETAG")} end)
+    |> expect(:fetch, fn _id, _etag -> {:ok, ConfigEntry.new(config, "ETAG")} end)
   end
 
   @spec expect_unchanged :: Mox.t()
   def expect_unchanged do
     MockFetcher
-    |> expect(:fetch, fn _id -> {:ok, :unchanged} end)
+    |> expect(:fetch, fn _id, _etag -> {:ok, :unchanged} end)
   end
 
   @spec expect_not_refreshed :: Mox.t()
   def expect_not_refreshed do
     MockFetcher
-    |> expect(:fetch, 0, fn _id -> :not_called end)
+    |> expect(:fetch, 0, fn _id, _etag -> :not_called end)
   end
 
   @spec assert_returns_error(function()) :: true
@@ -83,7 +83,7 @@ defmodule ConfigCat.CachePolicyCase do
     response = %Response{status_code: 503}
 
     MockFetcher
-    |> stub(:fetch, fn _id -> {:error, response} end)
+    |> stub(:fetch, fn _id, _etag -> {:error, response} end)
 
     assert {:error, ^response} = force_refresh_fn.()
   end


### PR DESCRIPTION
### Describe the purpose of your pull request

Now that we include the ETag in the latest cache entry, we don't need to store it in the ConfigFetcher's local state; instead, we pass it in to the fetcher.

**NOTE:** This PR is built on top of #93 and I've set the base branch accordingly. Once that PR is merged (or rejected), I'll rebase this PR before merging.

### Related issues (only if applicable)

This is a follow up to #90 / https://trello.com/c/eekAiFY3/6-lazyload-ttl-autopoll-interval-should-be-stored-in-cache-elixir.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
