### PR TITLE
✅ Add more auto/lazy tests

### DIFF
--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -24,11 +24,15 @@ defmodule ConfigCat.CachePolicyCase do
     {:ok, config: config}
   end
 
-  @spec start_cache_policy(CachePolicy.t()) :: {:ok, atom()}
-  def start_cache_policy(policy) do
+  @spec start_cache_policy(CachePolicy.t(), keyword()) :: {:ok, atom()}
+  def start_cache_policy(policy, options \\ []) do
     instance_id = UUID.uuid4() |> String.to_atom()
 
     {:ok, cache_key} = start_cache(instance_id)
+
+    if entry = options[:initial_entry] do
+      Cache.set(instance_id, entry)
+    end
 
     {:ok, pid} =
       start_supervised(
@@ -63,7 +67,9 @@ defmodule ConfigCat.CachePolicyCase do
   @spec expect_refresh(Config.t()) :: Mox.t()
   def expect_refresh(config) do
     MockFetcher
-    |> expect(:fetch, fn _id, _etag -> {:ok, ConfigEntry.new(config, "ETAG")} end)
+    |> expect(:fetch, fn _id, _etag ->
+      {:ok, ConfigEntry.new(config, "ETAG")}
+    end)
   end
 
   @spec expect_unchanged :: Mox.t()


### PR DESCRIPTION
### Describe the purpose of your pull request

Add tests to ensure that initial fetches don't happen if the cache is already populated with a recent entry.

The new tests helped me realize that I had the logic backward in auto mode, so I fixed that.

The fix made the offline test start to fail, so I simplified/refactored it a bit. That helped me realize that we weren't setting the online flag in the state before (possibly) re-fetching the config while going online, so the fetch wasn't actually happening.

These tests are similar in spirit to those in the other SDKs, but are unit tests that don't need as many sleeps/delays.

### Related issues (only if applicable)

Follow-up to #90.
Finishes https://trello.com/c/eekAiFY3/6-lazyload-ttl-autopoll-interval-should-be-stored-in-cache-elixir

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
