### PR TITLE
🔧 Catch compiler warnings

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -57,7 +57,12 @@ jobs:
     - name: Run dialyzer
       run: mix dialyzer
 
+    - name: Execute tests (Elixir 1.11.x)
+      if: matrix.elixir-version == '1.11.x'
+      run: mix coveralls.json
+
     - name: Execute tests
+      if: matrix.elixir-version != '1.11.x'
       run: mix coveralls.json --warnings-as-errors
 
     - name: Upload coverage report

--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -44,6 +44,9 @@ jobs:
         mix local.hex --force
         mix deps.get
 
+    - name: Compile
+      run: mix compile --warnings-as-errors
+
     - name: Check formatting
       if: matrix.elixir-version == env.ELIXIR_VERSION
       run: mix format --check-formatted
@@ -55,7 +58,7 @@ jobs:
       run: mix dialyzer
 
     - name: Execute tests
-      run: mix coveralls.json
+      run: mix coveralls.json --warnings-as-errors
 
     - name: Upload coverage report
       run: bash <(curl -s https://codecov.io/bash)

--- a/lib/config_cat/in_memory_cache.ex
+++ b/lib/config_cat/in_memory_cache.ex
@@ -33,7 +33,7 @@ defmodule ConfigCat.InMemoryCache do
   end
 
   @impl GenServer
-  def handle_call(:clear, _from, state) do
+  def handle_call(:clear, _from, _state) do
     {:reply, :ok, %{}}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,6 +13,7 @@ defmodule ConfigCat.MixProject do
       elixir: "~> 1.10",
       description: description(),
       package: package(),
+      elixirc_options: elixirc_options(Mix.env()),
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -40,6 +41,28 @@ defmodule ConfigCat.MixProject do
     [
       extra_applications: [:logger],
       mod: {ConfigCat.Application, []}
+    ]
+  end
+
+  defp elixirc_options(:dev) do
+    [
+      all_warnings: true,
+      ignore_module_conflict: true,
+      warnings_as_errors: false
+    ]
+  end
+
+  defp elixirc_options(:test) do
+    [
+      all_warnings: true,
+      warnings_as_error: false
+    ]
+  end
+
+  defp elixirc_options(_) do
+    [
+      all_warnings: true,
+      warnings_as_errors: true
     ]
   end
 


### PR DESCRIPTION
### Describe the purpose of your pull request

Set default options for the Elixir compiler in various environments to catch compiler warnings.

In dev and test, we allow compiler warnings (to allow running and testing incomplete code), but we make sure to continuously report those errors even when the affected files are not recompiled. That way, warnings don't appear once, get forgotten about, then disappear.

In production, we treat all warnings as errors.

In CI, we compile in the dev environment with `--warnings-as-errors` and also run the tests with the same flag.

Also, fix one compiler warning that snuck through from an earlier commit.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
