### PR TITLE
💥 Implement hooks

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -111,6 +111,9 @@ defmodule ConfigCat do
     `ConfigCat.LocalFileDataSource` and `ConfigCat.LocalMapDataSource` are
     provided for you to use.
 
+  - `hooks`: **OPTIONAL** Specify callback functions to be called when
+    particular events are fired by the SDK. See `ConfigCat.Hooks`.
+
   - `http_proxy`: **OPTIONAL** Specify this option if you need to use a proxy
     server to access your ConfigCat settings. You can provide a simple URL, like
     `https://my_proxy.example.com` or include authentication information, like
@@ -173,6 +176,7 @@ defmodule ConfigCat do
   alias ConfigCat.Client
   alias ConfigCat.Config
   alias ConfigCat.EvaluationDetails
+  alias ConfigCat.Hooks
   alias ConfigCat.OverrideDataSource
   alias ConfigCat.User
 
@@ -203,6 +207,7 @@ defmodule ConfigCat do
           | {:data_governance, data_governance()}
           | {:default_user, User.t()}
           | {:flag_overrides, OverrideDataSource.t()}
+          | {:hooks, [Hooks.option()]}
           | {:http_proxy, String.t()}
           | {:name, instance_id()}
           | {:offline, boolean()}
@@ -501,6 +506,22 @@ defmodule ConfigCat do
     options
     |> client()
     |> GenServer.call(:is_offline, Constants.fetch_timeout())
+  end
+
+  @doc """
+  Return the current hook callbacks.
+
+  ### Options
+
+  - `client`: If you are running multiple instances of `ConfigCat`, provide the
+    `client: :unique_name` option, specifying the name you configured for the
+    instance you want to access.
+  """
+  @spec hooks([api_option()]) :: Hooks.t()
+  def hooks(options \\ []) do
+    options
+    |> client()
+    |> GenServer.call(:hooks, Constants.fetch_timeout())
   end
 
   defp client(options) do

--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -519,9 +519,7 @@ defmodule ConfigCat do
   """
   @spec hooks([api_option()]) :: Hooks.t()
   def hooks(options \\ []) do
-    options
-    |> client()
-    |> GenServer.call(:hooks, Constants.fetch_timeout())
+    Keyword.get(options, :client, __MODULE__)
   end
 
   defp client(options) do

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -48,8 +48,7 @@ defmodule ConfigCat.CachePolicy do
 
   @typedoc "Options for auto-polling mode."
   @type auto_options :: [
-          {:on_changed, on_changed_callback()}
-          | {:poll_interval_seconds, pos_integer()}
+          {:poll_interval_seconds, pos_integer()}
         ]
 
   @typedoc "Options for lazy-polling mode."
@@ -85,17 +84,6 @@ defmodule ConfigCat.CachePolicy do
 
   ```elixir
   ConfigCat.CachePolicy.auto(poll_interval_seconds: 60)
-  ```
-
-  If you want your application to be notified whenever a new
-  configuration is available, provide a 0-arity callback function
-  using the `on_change` option.
-
-  The `on_change` callback is called asynchronously (using `Task.start`).
-  Any exceptions raised are caught and logged.
-
-  ```elixir
-  ConfigCat.CachePolicy.auto(on_changed: callback)
   ```
   """
   @spec auto(auto_options()) :: t()

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -109,8 +109,10 @@ defmodule ConfigCat.CachePolicy.Auto do
 
     if delay_ms == 0 do
       refresh(state)
+      Helpers.on_client_ready(state)
       schedule_next_refresh(state)
     else
+      Helpers.on_client_ready(state)
       Process.send_after(self(), :polled_refresh, delay_ms)
     end
   end

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -7,6 +7,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
   alias ConfigCat.ConfigCache
   alias ConfigCat.ConfigEntry
   alias ConfigCat.FetchTime
+  alias ConfigCat.Hooks
 
   defmodule State do
     @moduledoc false
@@ -51,6 +52,11 @@ defmodule ConfigCat.CachePolicy.Helpers do
     instance_id = Keyword.fetch!(options, :instance_id)
 
     GenServer.start_link(module, State.new(options), name: CachePolicy.via_tuple(instance_id))
+  end
+
+  @spec on_client_ready(State.t()) :: :ok
+  def on_client_ready(%State{} = state) do
+    Hooks.invoke_on_client_ready(state.instance_id)
   end
 
   @spec cached_settings(State.t()) ::

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -100,6 +100,11 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
       {:ok, %ConfigEntry{} = entry} ->
         update_cache(state, entry)
+
+        with {:ok, settings} <- Config.fetch_settings(entry.config) do
+          Hooks.invoke_on_config_changed(state.instance_id, settings)
+        end
+
         :ok
 
       error ->

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -28,7 +28,13 @@ defmodule ConfigCat.CachePolicy.Lazy do
 
   @impl GenServer
   def init(state) do
-    {:ok, state}
+    {:ok, state, {:continue, :on_client_ready}}
+  end
+
+  @impl GenServer
+  def handle_continue(:on_client_ready, %State{} = state) do
+    Helpers.on_client_ready(state)
+    {:noreply, state}
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -21,7 +21,13 @@ defmodule ConfigCat.CachePolicy.Manual do
 
   @impl GenServer
   def init(state) do
-    {:ok, state}
+    {:ok, state, {:continue, :on_client_ready}}
+  end
+
+  @impl GenServer
+  def handle_continue(:on_client_ready, %State{} = state) do
+    Helpers.on_client_ready(state)
+    {:noreply, state}
   end
 
   @impl GenServer

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -225,6 +225,7 @@ defmodule ConfigCat.Client do
             default_value?: true,
             error: message,
             key: key,
+            user: user,
             value: default_value,
             variation_id: default_variation_id
           )

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -162,11 +162,6 @@ defmodule ConfigCat.Client do
     {:reply, result, state}
   end
 
-  @impl GenServer
-  def handle_call(:hooks, _from, %State{} = state) do
-    {:reply, state.instance_id, state}
-  end
-
   defp do_get_value(key, default_value, user, %State{} = state) do
     %EvaluationDetails{value: value} = evaluate(key, user, default_value, nil, state)
     value

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -162,6 +162,11 @@ defmodule ConfigCat.Client do
     {:reply, result, state}
   end
 
+  @impl GenServer
+  def handle_call(:hooks, _from, %State{} = state) do
+    {:reply, state.instance_id, state}
+  end
+
   defp do_get_value(key, default_value, user, %State{} = state) do
     %EvaluationDetails{value: value} = evaluate(key, user, default_value, nil, state)
     value

--- a/lib/config_cat/error_reporter.ex
+++ b/lib/config_cat/error_reporter.ex
@@ -1,0 +1,22 @@
+defmodule ConfigCat.ErrorReporter do
+  @moduledoc false
+
+  @type opt :: {:instance_id, ConfigCat.instance_id()} | {:skip_hook?, boolean()}
+
+  @spec call(String.t()) :: Macro.t()
+  @spec call(String.t(), [opt]) :: Macro.t()
+  defmacro call(message, opts \\ []) do
+    instance_id = Keyword.fetch!(opts, :instance_id)
+    skip_hook? = Keyword.get(opts, :skip_hook?, false)
+
+    quote bind_quoted: [instance_id: instance_id, message: message, skip_hook?: skip_hook?] do
+      require Logger
+
+      Logger.error(message)
+
+      unless skip_hook? do
+        ConfigCat.Hooks.invoke_on_error(instance_id, message)
+      end
+    end
+  end
+end

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -1,0 +1,149 @@
+defmodule ConfigCat.Hooks do
+  @moduledoc """
+  Subscribe to events fired by the SDK.
+
+  Hooks are callback functions that are called by the SDK when certain events
+  happen. Client applications can register more than one callback for each hook.
+
+  Callbacks are called within the same process that generated the event. Any
+  exceptions that are raised by a callback are rescued, logged, and reported to
+  any registered `on_error` callbacks.
+
+  The following callbacks are available:
+  - `on_client_ready`: This event is sent when the SDK reaches the ready state.
+    If the SDK is set up with lazy load or manual polling it's considered ready
+    right after instantiation. If it's using auto polling, the ready state is
+    reached when the SDK has a valid config JSON loaded into memory either from
+    cache or from HTTP.
+  - `on_config_changed(config: map())`: This event is sent when the SDK loads a
+    valid config JSON into memory from cache, and each subsequent time when the
+    loaded config JSON changes via HTTP.
+  - `on_flag_evaluated(evaluation_details: EvaluationDetails.t())`: This event
+    is sent each time when the SDK evaluates a feature flag or setting. The
+    event sends the same evaluation details that you would get from
+    get_value_details.
+  - on_error(error: String.t()): This event is sent when an error occurs within the
+    ConfigCat SDK.
+  """
+  use TypedStruct
+
+  alias ConfigCat.Config
+  alias ConfigCat.EvaluationDetails
+
+  require Logger
+
+  @type on_client_ready_callback :: (() -> term()) | mfa()
+  @type on_config_changed_callback :: (Config.t() -> term()) | mfa()
+  @type on_error_callback :: (String.t() -> term()) | mfa()
+  @type on_flag_evaluated_callback :: (EvaluationDetails.t() -> term()) | mfa()
+  @type option ::
+          {:on_client_ready, on_client_ready_callback()}
+          | {:on_config_changed, on_config_changed_callback()}
+          | {:on_error, on_error_callback()}
+          | {:on_flag_evaluated, on_flag_evaluated_callback()}
+
+  typedstruct opaque: true do
+    field :on_client_ready, [on_client_ready_callback()], default: []
+    field :on_config_changed, [on_config_changed_callback()], default: []
+    field :on_error, [on_error_callback()], default: []
+    field :on_flag_evaluated, [on_flag_evaluated_callback()], default: []
+  end
+
+  @doc """
+  Create a new `ConfigCat.Hooks` struct with the given callbacks.
+  """
+  @spec new([option]) :: t()
+  def new(options \\ []) do
+    hooks = Enum.map(options, fn {key, value} -> {key, List.wrap(value)} end)
+    struct!(__MODULE__, hooks)
+  end
+
+  @doc """
+  Add an `on_client_ready` callback.
+  """
+  @spec add_on_client_ready(t(), on_client_ready_callback()) :: t()
+  def add_on_client_ready(%__MODULE__{} = hooks, callback) do
+    Map.update!(hooks, :on_client_ready, &[callback | &1])
+  end
+
+  @doc """
+  Add an `on_config_changed` callback.
+  """
+  @spec add_on_config_changed(t(), on_config_changed_callback()) :: t()
+  def add_on_config_changed(%__MODULE__{} = hooks, callback) do
+    Map.update!(hooks, :on_config_changed, &[callback | &1])
+  end
+
+  @doc """
+  Add an `on_error` callback.
+  """
+  @spec add_on_error(t(), on_error_callback()) :: t()
+  def add_on_error(%__MODULE__{} = hooks, callback) do
+    Map.update!(hooks, :on_error, &[callback | &1])
+  end
+
+  @doc """
+  Add an `on_flag_evaluated` callback.
+  """
+  @spec add_on_flag_evaluated(t(), on_flag_evaluated_callback()) :: t()
+  def add_on_flag_evaluated(%__MODULE__{} = hooks, callback) do
+    Map.update!(hooks, :on_flag_evaluated, &[callback | &1])
+  end
+
+  @doc false
+  @spec invoke_on_client_ready(t()) :: :ok
+  def invoke_on_client_ready(%__MODULE__{} = hooks) do
+    invoke_callbacks(hooks, :on_client_ready, [])
+  end
+
+  @doc false
+  @spec invoke_on_config_changed(t(), Config.t()) :: :ok
+  def invoke_on_config_changed(%__MODULE__{} = hooks, config) do
+    invoke_callbacks(hooks, :on_config_changed, [config])
+  end
+
+  @doc false
+  @spec invoke_on_error(t(), String.t()) :: :ok
+  def invoke_on_error(%__MODULE__{} = hooks, message) do
+    invoke_callbacks(hooks, :on_error, [message])
+  end
+
+  @doc false
+  @spec invoke_on_flag_evaluated(t(), EvaluationDetails.t()) :: :ok
+  def invoke_on_flag_evaluated(%__MODULE__{} = hooks, %EvaluationDetails{} = details) do
+    invoke_callbacks(hooks, :on_flag_evaluated, [details])
+  end
+
+  defp invoke_callbacks(hooks, name, args) do
+    hooks
+    |> Map.fetch!(name)
+    |> Enum.each(fn callback ->
+      try do
+        invoke_callback(callback, args)
+      rescue
+        e ->
+          error = "Exception occurred during invoke_#{name} callback: #{inspect(e)}"
+
+          unless name == :on_error do
+            Logger.error(error)
+            invoke_on_error(hooks, error)
+          end
+      end
+    end)
+
+    :ok
+  end
+
+  defp invoke_callback(callback, args) when is_function(callback) do
+    apply(callback, args)
+  end
+
+  defp invoke_callback({module, function, arity}, args) when length(args) == arity do
+    apply(module, function, args)
+  end
+
+  defp invoke_callback({module, function, arity}, args) do
+    raise ArgumentError,
+          "Callback #{module}.#{function}/#{arity} has incorrect arity. Expected #{length(args)} but was #{arity}."
+  end
+end

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -31,10 +31,33 @@ defmodule ConfigCat.Hooks do
   alias ConfigCat.EvaluationDetails
   alias ConfigCat.Hooks.State
 
-  @type on_client_ready_callback :: (() -> term()) | mfa()
-  @type on_config_changed_callback :: (Config.t() -> term()) | mfa()
-  @type on_error_callback :: (String.t() -> term()) | mfa()
-  @type on_flag_evaluated_callback :: (EvaluationDetails.t() -> term()) | mfa()
+  @typedoc """
+  A module/function name/extra arguments tuple representing a callback function.
+
+  Each callback passes specific arguments. These specific arguments are
+  prepended to the extra arguments provided in the tuple (if any).
+
+  For example, you might want to define a callback that sends a message to
+  another process which the config changes. You can pass the pid of that process
+  as an extra argument:
+
+  ```elixir
+  def MyModule do
+    def subscribe_to_config_changes(subscriber_pid) do
+      ConfigCat.hooks()
+      |> ConfigCat.Hooks.add_on_config_changed({__MODULE__, :on_config_changed, [subscriber_pid]})
+    end
+
+    def on_config_changed(config, pid) do
+      send pid, {:config_changed, config}
+    end
+  end
+  """
+  @type named_callback :: {module(), atom(), list()}
+  @type on_client_ready_callback :: (() -> term()) | named_callback()
+  @type on_config_changed_callback :: (Config.t() -> term()) | named_callback()
+  @type on_error_callback :: (String.t() -> term()) | named_callback()
+  @type on_flag_evaluated_callback :: (EvaluationDetails.t() -> term()) | named_callback()
   @type option ::
           {:on_client_ready, on_client_ready_callback()}
           | {:on_config_changed, on_config_changed_callback()}

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -119,32 +119,38 @@ defmodule ConfigCat.Hooks do
   @spec invoke_on_client_ready(t()) :: :ok
   def invoke_on_client_ready(instance_id) do
     instance_id
-    |> via_tuple()
-    |> GenServer.call({:invoke_hook, :on_client_ready, []})
+    |> hooks()
+    |> State.invoke_hook(:on_client_ready, [])
   end
 
   @doc false
   @spec invoke_on_config_changed(t(), Config.t()) :: :ok
   def invoke_on_config_changed(instance_id, config) do
     instance_id
-    |> via_tuple()
-    |> GenServer.call({:invoke_hook, :on_config_changed, [config]})
+    |> hooks()
+    |> State.invoke_hook(:on_config_changed, [config])
   end
 
   @doc false
   @spec invoke_on_error(t(), String.t()) :: :ok
   def invoke_on_error(instance_id, message) do
     instance_id
-    |> via_tuple()
-    |> GenServer.call({:invoke_hook, :on_error, [message]})
+    |> hooks()
+    |> State.invoke_hook(:on_error, [message])
   end
 
   @doc false
   @spec invoke_on_flag_evaluated(t(), EvaluationDetails.t()) :: :ok
   def invoke_on_flag_evaluated(instance_id, %EvaluationDetails{} = details) do
     instance_id
+    |> hooks()
+    |> State.invoke_hook(:on_flag_evaluated, [details])
+  end
+
+  defp hooks(instance_id) do
+    instance_id
     |> via_tuple()
-    |> GenServer.call({:invoke_hook, :on_flag_evaluated, [details]})
+    |> GenServer.call(:hooks)
   end
 
   defp via_tuple(instance_id) do
@@ -163,9 +169,7 @@ defmodule ConfigCat.Hooks do
   end
 
   @impl GenServer
-  def handle_call({:invoke_hook, hook, args}, _from, %State{} = state) do
-    result = State.invoke_hook(state, hook, args)
-
-    {:reply, result, state}
+  def handle_call(:hooks, _from, %State{} = state) do
+    {:reply, state, state}
   end
 end

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -54,10 +54,10 @@ defmodule ConfigCat.Hooks do
   end
   """
   @type named_callback :: {module(), atom(), list()}
-  @type on_client_ready_callback :: (() -> term()) | named_callback()
-  @type on_config_changed_callback :: (Config.t() -> term()) | named_callback()
-  @type on_error_callback :: (String.t() -> term()) | named_callback()
-  @type on_flag_evaluated_callback :: (EvaluationDetails.t() -> term()) | named_callback()
+  @type on_client_ready_callback :: (() -> any()) | named_callback()
+  @type on_config_changed_callback :: (Config.settings() -> any()) | named_callback()
+  @type on_error_callback :: (String.t() -> any()) | named_callback()
+  @type on_flag_evaluated_callback :: (EvaluationDetails.t() -> any()) | named_callback()
   @type option ::
           {:on_client_ready, on_client_ready_callback()}
           | {:on_config_changed, on_config_changed_callback()}
@@ -132,11 +132,11 @@ defmodule ConfigCat.Hooks do
   end
 
   @doc false
-  @spec invoke_on_config_changed(t(), Config.t()) :: :ok
-  def invoke_on_config_changed(instance_id, config) do
+  @spec invoke_on_config_changed(t(), Config.settings()) :: :ok
+  def invoke_on_config_changed(instance_id, settings) do
     instance_id
     |> hooks()
-    |> State.invoke_hook(:on_config_changed, [config])
+    |> State.invoke_hook(:on_config_changed, [settings])
   end
 
   @doc false

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -78,41 +78,49 @@ defmodule ConfigCat.Hooks do
   @doc """
   Add an `on_client_ready` callback.
   """
-  @spec add_on_client_ready(t(), on_client_ready_callback()) :: :ok
+  @spec add_on_client_ready(t(), on_client_ready_callback()) :: t()
   def add_on_client_ready(instance_id, callback) do
     instance_id
     |> via_tuple()
     |> GenServer.call({:add_hook, :on_client_ready, callback})
+
+    instance_id
   end
 
   @doc """
   Add an `on_config_changed` callback.
   """
-  @spec add_on_config_changed(t(), on_config_changed_callback()) :: :ok
+  @spec add_on_config_changed(t(), on_config_changed_callback()) :: t()
   def add_on_config_changed(instance_id, callback) do
     instance_id
     |> via_tuple()
     |> GenServer.call({:add_hook, :on_config_changed, callback})
+
+    instance_id
   end
 
   @doc """
   Add an `on_error` callback.
   """
-  @spec add_on_error(t(), on_error_callback()) :: :ok
+  @spec add_on_error(t(), on_error_callback()) :: t()
   def add_on_error(instance_id, callback) do
     instance_id
     |> via_tuple()
     |> GenServer.call({:add_hook, :on_error, callback})
+
+    instance_id
   end
 
   @doc """
   Add an `on_flag_evaluated` callback.
   """
-  @spec add_on_flag_evaluated(t(), on_flag_evaluated_callback()) :: :ok
+  @spec add_on_flag_evaluated(t(), on_flag_evaluated_callback()) :: t()
   def add_on_flag_evaluated(instance_id, callback) do
     instance_id
     |> via_tuple()
     |> GenServer.call({:add_hook, :on_flag_evaluated, callback})
+
+    instance_id
   end
 
   @doc false

--- a/lib/config_cat/hooks/state.ex
+++ b/lib/config_cat/hooks/state.ex
@@ -4,7 +4,7 @@ defmodule ConfigCat.Hooks.State do
 
   require Logger
 
-  @type callback :: fun()
+  @type callback :: fun() | tuple()
   @type hook :: :on_client_ready | :on_config_changed | :on_error | :on_flag_evaluated
 
   typedstruct do
@@ -50,12 +50,7 @@ defmodule ConfigCat.Hooks.State do
     apply(callback, args)
   end
 
-  defp invoke_callback({module, function, arity}, args) when length(args) == arity do
-    apply(module, function, args)
-  end
-
-  defp invoke_callback({module, function, arity}, args) do
-    raise ArgumentError,
-          "Callback #{module}.#{function}/#{arity} has incorrect arity. Expected #{length(args)} but was #{arity}."
+  defp invoke_callback({module, function, extra_args}, args) do
+    apply(module, function, args ++ extra_args)
   end
 end

--- a/lib/config_cat/hooks/state.ex
+++ b/lib/config_cat/hooks/state.ex
@@ -1,0 +1,61 @@
+defmodule ConfigCat.Hooks.State do
+  @moduledoc false
+  use TypedStruct
+
+  require Logger
+
+  @type callback :: fun()
+  @type hook :: :on_client_ready | :on_config_changed | :on_error | :on_flag_evaluated
+
+  typedstruct do
+    field :on_client_ready, [callback()], default: []
+    field :on_config_changed, [callback()], default: []
+    field :on_error, [callback()], default: []
+    field :on_flag_evaluated, [callback()], default: []
+  end
+
+  @spec new(keyword()) :: t()
+  def new(options \\ []) do
+    hooks = Enum.map(options, fn {key, value} -> {key, List.wrap(value)} end)
+    struct!(__MODULE__, hooks)
+  end
+
+  @spec add_hook(t(), hook(), callback()) :: t()
+  def add_hook(%__MODULE__{} = state, hook, callback) do
+    Map.update!(state, hook, &[callback | &1])
+  end
+
+  @spec invoke_hook(t(), hook(), [any()]) :: :ok
+  def invoke_hook(%__MODULE__{} = state, hook, args) do
+    state
+    |> Map.fetch!(hook)
+    |> Enum.each(fn callback ->
+      try do
+        invoke_callback(callback, args)
+      rescue
+        e ->
+          error = "Exception occurred during #{hook} callback: #{inspect(e)}"
+
+          unless hook == :on_error do
+            Logger.error(error)
+            invoke_hook(state, :on_error, [error])
+          end
+      end
+    end)
+
+    :ok
+  end
+
+  defp invoke_callback(callback, args) when is_function(callback) do
+    apply(callback, args)
+  end
+
+  defp invoke_callback({module, function, arity}, args) when length(args) == arity do
+    apply(module, function, args)
+  end
+
+  defp invoke_callback({module, function, arity}, args) do
+    raise ArgumentError,
+          "Callback #{module}.#{function}/#{arity} has incorrect arity. Expected #{length(args)} but was #{arity}."
+  end
+end

--- a/lib/config_cat/rollout.ex
+++ b/lib/config_cat/rollout.ex
@@ -56,6 +56,7 @@ defmodule ConfigCat.Rollout do
           default_value?: true,
           error: message,
           key: key,
+          user: user,
           value: default_value,
           variation_id: default_variation_id
         )

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -7,6 +7,7 @@ defmodule ConfigCat.Supervisor do
   alias ConfigCat.CacheControlConfigFetcher
   alias ConfigCat.CachePolicy
   alias ConfigCat.Client
+  alias ConfigCat.Hooks
   alias ConfigCat.InMemoryCache
   alias ConfigCat.NullDataSource
   alias ConfigCat.OverrideDataSource
@@ -53,6 +54,7 @@ defmodule ConfigCat.Supervisor do
 
     children =
       [
+        hooks(options),
         cache(options),
         config_fetcher(options, override_behaviour),
         cache_policy(options, override_behaviour),
@@ -61,6 +63,11 @@ defmodule ConfigCat.Supervisor do
       |> Enum.reject(&is_nil/1)
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp hooks(options) do
+    hooks_options = Keyword.take(options, [:hooks, :instance_id])
+    {Hooks, hooks_options}
   end
 
   defp cache(options) do

--- a/test/config_cat/cache_test.exs
+++ b/test/config_cat/cache_test.exs
@@ -4,11 +4,13 @@ defmodule ConfigCat.CacheTest do
   import Mox
 
   alias ConfigCat.Cache
+  alias ConfigCat.Config
   alias ConfigCat.ConfigEntry
   alias ConfigCat.Hooks
   alias ConfigCat.MockConfigCache
 
-  @entry ConfigEntry.new(%{"some" => "config"}, "ETAG")
+  @config Config.new_with_settings(%{})
+  @entry ConfigEntry.new(@config, "ETAG")
   @serialized ConfigEntry.serialize(@entry)
 
   describe "generating a cache key" do

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -6,6 +6,7 @@ defmodule ConfigCat.ConfigFetcherTest do
   alias ConfigCat.CacheControlConfigFetcher, as: ConfigFetcher
   alias ConfigCat.ConfigEntry
   alias ConfigCat.FetchTime
+  alias ConfigCat.Hooks
   alias ConfigCat.MockAPI
   alias HTTPoison.Response
 
@@ -22,6 +23,9 @@ defmodule ConfigCat.ConfigFetcherTest do
 
   defp start_fetcher(%{mode: mode, sdk_key: sdk_key}, options \\ []) do
     instance_id = UUID.uuid4() |> String.to_atom()
+
+    start_supervised!({Hooks, instance_id: instance_id})
+
     default_options = [api: MockAPI, mode: mode, instance_id: instance_id, sdk_key: sdk_key]
 
     {:ok, pid} = start_supervised({ConfigFetcher, Keyword.merge(default_options, options)})

--- a/test/config_cat/hooks_test.exs
+++ b/test/config_cat/hooks_test.exs
@@ -1,0 +1,111 @@
+defmodule ConfigCat.HooksTest do
+  use ExUnit.Case, async: true
+
+  alias ConfigCat.Hooks
+
+  test "calls initial hook when invoked" do
+    callback = fn ->
+      send(self(), :on_client_ready_called)
+    end
+
+    hooks = Hooks.new(on_client_ready: callback)
+
+    assert :ok = Hooks.invoke_on_client_ready(hooks)
+    assert_received :on_client_ready_called
+  end
+
+  test "calls subscribed hook when invoked" do
+    message = "Some error message"
+
+    callback = fn msg ->
+      send(self(), {:on_error_called, msg})
+    end
+
+    hooks =
+      Hooks.new()
+      |> Hooks.add_on_error(callback)
+
+    assert :ok = Hooks.invoke_on_error(hooks, message)
+    assert_received {:on_error_called, ^message}
+  end
+
+  test "calls multiple hooks" do
+    callback1 = fn -> send(self(), :callback1_called) end
+    callback2 = fn -> send(self(), :callback2_called) end
+
+    hooks =
+      Hooks.new(on_client_ready: callback1)
+      |> Hooks.add_on_client_ready(callback2)
+
+    assert :ok = Hooks.invoke_on_client_ready(hooks)
+
+    assert_received :callback1_called
+    assert_received :callback2_called
+  end
+
+  @tag capture_log: true
+  test "calls later hooks even when earlier one fails" do
+    fail_callback = fn -> raise "Callback failed" end
+    good_callback = fn -> send(self(), :good_callback_called) end
+
+    hooks =
+      Hooks.new(on_client_ready: fail_callback)
+      |> Hooks.add_on_client_ready(good_callback)
+
+    assert :ok = Hooks.invoke_on_client_ready(hooks)
+
+    assert_received :good_callback_called
+  end
+
+  @tag capture_log: true
+  test "calls on_error hook when other hook fails" do
+    message = "Callback failed"
+    fail_callback = fn -> raise message end
+    on_error_callback = fn msg -> send(self(), {:on_error_called, msg}) end
+
+    hooks = Hooks.new(on_client_ready: fail_callback, on_error: on_error_callback)
+
+    assert :ok = Hooks.invoke_on_client_ready(hooks)
+
+    assert_received {:on_error_called, received}
+    assert received =~ message
+  end
+
+  @tag capture_log: true
+  @tag timeout: 1_000
+  test "does not call on_error hook recursively" do
+    fail_callback = fn _msg -> raise "Callback failed" end
+
+    hooks = Hooks.new(on_error: fail_callback)
+
+    assert :ok = Hooks.invoke_on_error(hooks, "Some error")
+
+    # If this test finishes without timing out, we successfully avoided an
+    # infinite recursion of calling the failed on_error callback.
+  end
+
+  test "allows module/function/arity as a hook" do
+    hooks = Hooks.new(on_client_ready: {__MODULE__, :on_client_ready, 0})
+
+    assert :ok = Hooks.invoke_on_client_ready(hooks)
+
+    assert_received :on_client_ready_mfa_called
+  end
+
+  @tag capture_log: true
+  test "fails if module/function/arity hook has wrong arity" do
+    on_error = fn message -> send(self(), {:on_error, message}) end
+    hooks = Hooks.new(on_config_changed: {__MODULE__, :on_client_ready, 0}, on_error: on_error)
+
+    assert :ok = Hooks.invoke_on_config_changed(hooks, %{})
+
+    assert_received {:on_error, message}
+    assert message =~ "has incorrect arity"
+  end
+
+  @spec on_client_ready :: :ok
+  def on_client_ready do
+    send(self(), :on_client_ready_mfa_called)
+    :ok
+  end
+end

--- a/test/config_cat/hooks_test.exs
+++ b/test/config_cat/hooks_test.exs
@@ -6,6 +6,7 @@ defmodule ConfigCat.HooksTest do
 
   alias ConfigCat.CachePolicy
   alias ConfigCat.Client
+  alias ConfigCat.Config
   alias ConfigCat.ConfigEntry
   alias ConfigCat.EvaluationDetails
   alias ConfigCat.Hooks
@@ -83,9 +84,13 @@ defmodule ConfigCat.HooksTest do
 
     value = ConfigCat.get_value("testStringKey", "", client: instance_id)
 
+    {:ok, settings} = Config.fetch_settings(@config)
+
     assert value == "testValue"
     assert_received :on_client_ready
+    assert_received {:on_config_changed, ^settings}
     assert_received {:on_flag_evaluated, _details}
+
     refute_received {:on_error, _error}
     refute_received _any_other_messages
   end
@@ -106,8 +111,11 @@ defmodule ConfigCat.HooksTest do
 
     value = ConfigCat.get_value("testStringKey", "", client: instance_id)
 
+    {:ok, settings} = Config.fetch_settings(@config)
+
     assert value == "testValue"
     assert_received :on_client_ready
+    assert_received {:on_config_changed, ^settings}
     assert_received {:on_flag_evaluated, _details}
     refute_received {:on_error, _error}
     refute_received _any_other_messages

--- a/test/config_cat/hooks_test.exs
+++ b/test/config_cat/hooks_test.exs
@@ -86,10 +86,12 @@ defmodule ConfigCat.HooksTest do
 
     {:ok, instance_id} = start_hooks()
 
-    :ok = Hooks.add_on_client_ready(instance_id, {TestHooks, :on_client_ready, [test_pid]})
-    :ok = Hooks.add_on_config_changed(instance_id, {TestHooks, :on_config_changed, [test_pid]})
-    :ok = Hooks.add_on_flag_evaluated(instance_id, {TestHooks, :on_flag_evaluated, [test_pid]})
-    :ok = Hooks.add_on_error(instance_id, {TestHooks, :on_error, [test_pid]})
+    _hooks =
+      ConfigCat.hooks(client: instance_id)
+      |> Hooks.add_on_client_ready({TestHooks, :on_client_ready, [test_pid]})
+      |> Hooks.add_on_config_changed({TestHooks, :on_config_changed, [test_pid]})
+      |> Hooks.add_on_flag_evaluated({TestHooks, :on_flag_evaluated, [test_pid]})
+      |> Hooks.add_on_error({TestHooks, :on_error, [test_pid]})
 
     :ok = start_client(instance_id: instance_id)
 

--- a/test/config_cat/hooks_test.exs
+++ b/test/config_cat/hooks_test.exs
@@ -1,0 +1,134 @@
+defmodule ConfigCat.HooksTest do
+  use ConfigCat.CachePolicyCase, async: true
+
+  import Jason.Sigil
+
+  alias ConfigCat.CachePolicy
+  alias ConfigCat.Client
+  alias ConfigCat.ConfigEntry
+  alias ConfigCat.Hooks
+  alias ConfigCat.NullDataSource
+
+  @moduletag capture_log: true
+
+  @config ~J"""
+  {
+    "p": {
+      "u": "https://cdn-global.configcat.com",
+      "r": 0
+    },
+    "f": {
+      "testBoolKey": {"v": true,"t": 0, "p": [],"r": []},
+      "testStringKey": {"v": "testValue", "i": "id", "t": 1, "p": [],"r": [
+        {"i":"id1","v":"fake1","a":"Identifier","t":2,"c":"@test1.com"},
+        {"i":"id2","v":"fake2","a":"Identifier","t":2,"c":"@test2.com"}
+      ]},
+      "testIntKey": {"v": 1,"t": 2, "p": [],"r": []},
+      "testDoubleKey": {"v": 1.1,"t": 3,"p": [],"r": []},
+      "key1": {"v": true, "i": "fakeId1","p": [], "r": []},
+      "key2": {"v": false, "i": "fakeId2","p": [], "r": []}
+    }
+  }
+  """
+  @policy CachePolicy.manual()
+
+  defmodule TestHooks do
+    @moduledoc false
+    alias ConfigCat.Config
+    alias ConfigCat.EvaluationDetails
+
+    @spec on_client_ready(pid()) :: :ok
+    def on_client_ready(test_pid) do
+      send(test_pid, :on_client_ready)
+      :ok
+    end
+
+    @spec on_config_changed(Config.t(), pid()) :: :ok
+    def on_config_changed(config, test_pid) do
+      send(test_pid, {:on_config_changed, config})
+      :ok
+    end
+
+    @spec on_flag_evaluated(EvaluationDetails.t(), pid()) :: :ok
+    def on_flag_evaluated(%EvaluationDetails{} = details, test_pid) do
+      send(test_pid, {:on_flag_evaluated, details})
+      :ok
+    end
+
+    @spec on_error(String.t(), pid()) :: :ok
+    def on_error(message, test_pid) do
+      send(test_pid, {:on_error, message})
+      :ok
+    end
+  end
+
+  test "calls initial hooks" do
+    test_pid = self()
+
+    {:ok, instance_id} =
+      start_hooks(
+        on_client_ready: {TestHooks, :on_client_ready, [test_pid]},
+        on_config_changed: {TestHooks, :on_config_changed, [test_pid]},
+        on_flag_evaluated: {TestHooks, :on_flag_evaluated, [test_pid]},
+        on_error: {TestHooks, :on_error, [test_pid]}
+      )
+
+    :ok = start_client(instance_id: instance_id)
+
+    value = ConfigCat.get_value("testStringKey", "", client: instance_id)
+
+    assert value == "testValue"
+    assert_received :on_client_ready
+  end
+
+  test "calls subscribed hooks" do
+    test_pid = self()
+
+    {:ok, instance_id} = start_hooks()
+
+    :ok = Hooks.add_on_client_ready(instance_id, {TestHooks, :on_client_ready, [test_pid]})
+    :ok = Hooks.add_on_config_changed(instance_id, {TestHooks, :on_config_changed, [test_pid]})
+    :ok = Hooks.add_on_flag_evaluated(instance_id, {TestHooks, :on_flag_evaluated, [test_pid]})
+    :ok = Hooks.add_on_error(instance_id, {TestHooks, :on_error, [test_pid]})
+
+    :ok = start_client(instance_id: instance_id)
+
+    value = ConfigCat.get_value("testStringKey", "", client: instance_id)
+
+    assert value == "testValue"
+    assert_received :on_client_ready
+  end
+
+  defp start_hooks(config \\ []) do
+    instance_id = UUID.uuid4() |> String.to_atom()
+
+    start_supervised!({Hooks, hooks: config, instance_id: instance_id})
+
+    {:ok, instance_id}
+  end
+
+  defp start_client(opts) do
+    initial_entry =
+      Keyword.get_lazy(opts, :initial_entry, fn ->
+        ConfigEntry.new(@config, "test-etag")
+      end)
+
+    instance_id = opts[:instance_id]
+
+    {:ok, instance_id} =
+      start_cache_policy(@policy,
+        initial_entry: initial_entry,
+        instance_id: instance_id,
+        start_hooks?: false
+      )
+
+    client_options = [
+      flag_overrides: NullDataSource.new(),
+      instance_id: instance_id
+    ]
+
+    start_supervised!({Client, client_options})
+
+    :ok
+  end
+end

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -55,7 +55,8 @@ defmodule ConfigCat.CachePolicyCase do
     {:ok, cache_key} = start_cache(instance_id)
 
     if entry = options[:initial_entry] do
-      Cache.set(instance_id, entry)
+      # Bypass Cache to force it to refresh itself on first call.
+      InMemoryCache.set(cache_key, ConfigEntry.serialize(entry))
     end
 
     {:ok, pid} =

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -9,6 +9,7 @@ defmodule ConfigCat.CachePolicyCase do
   alias ConfigCat.CachePolicy
   alias ConfigCat.Config
   alias ConfigCat.ConfigEntry
+  alias ConfigCat.Hooks
   alias ConfigCat.InMemoryCache
   alias ConfigCat.MockFetcher
   alias HTTPoison.Response
@@ -44,7 +45,12 @@ defmodule ConfigCat.CachePolicyCase do
 
   @spec start_cache_policy(CachePolicy.t(), keyword()) :: {:ok, atom()}
   def start_cache_policy(policy, options \\ []) do
-    instance_id = UUID.uuid4() |> String.to_atom()
+    instance_id =
+      Keyword.get_lazy(options, :instance_id, fn -> UUID.uuid4() |> String.to_atom() end)
+
+    if Keyword.get(options, :start_hooks?, true) do
+      start_supervised!({Hooks, instance_id: instance_id})
+    end
 
     {:ok, cache_key} = start_cache(instance_id)
 

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -5,6 +5,7 @@ defmodule ConfigCat.ClientCase do
 
   alias ConfigCat.Client
   alias ConfigCat.FetchTime
+  alias ConfigCat.Hooks
   alias ConfigCat.MockCachePolicy
   alias ConfigCat.NullDataSource
 
@@ -17,6 +18,8 @@ defmodule ConfigCat.ClientCase do
   @spec start_client([Client.option()]) :: {:ok, GenServer.server()}
   def start_client(opts \\ []) do
     instance_id = UUID.uuid4() |> String.to_atom()
+
+    start_supervised!({Hooks, instance_id: instance_id})
 
     options =
       [


### PR DESCRIPTION
### Describe the purpose of your pull request

Implements the new hooks feature to allow users to supply callbacks that are called when significant events occur.

I based this implementation largely off of the Ruby SDK with necessary adjustments to accommodate Elixir's functional nature.

In particular, I chose to implement `ConfigCat.hooks`, which returns an opaque value (actually a `ConfigCat.instance_id`) that can later be passed to `Hooks.add_*_callback` as this is consistent with the other SDKs. I think a better option for Elixir would be to add the `add_*_callback` functions directly to `ConfigCat` instead. That way, `ConfigCat` can continue to serve as a facade for the entire library and users don't have to worry about calling functions on other modules.  Let me know if you'd prefer this option.

In order to store the configured hooks separately for each instance, I made `Hooks` into a GenServer, but ensured that the hooks are invoked in the calling process rather than in the GenServer's process. That way, the GenServer doesn't become a bottleneck.

The `on_error` callback is not yet called everywhere it should be. In order to call it, we need an `instance_id` and it's not easy to get it everywhere it needs to be.  I have an idea to address this that will also address #51, so I'll do that in a follow-up PR.

### Related issues (only if applicable)

https://trello.com/c/FRaC8jzd/7-hooks-elixir

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
