### PR TITLE
♻️ Consistent fetch logic

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -217,7 +217,7 @@ defmodule ConfigCat do
   @type options :: [option()]
 
   @typedoc "The return value of the `force_refresh/1` function."
-  @type refresh_result :: :ok | {:error, term()}
+  @type refresh_result :: :ok | {:error, String.t()}
 
   @typedoc "The actual value of a configuration setting."
   @type value :: Config.value()

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -40,7 +40,6 @@ defmodule ConfigCat.CachePolicy do
   alias ConfigCat.CachePolicy.Behaviour
   alias ConfigCat.CachePolicy.Lazy
   alias ConfigCat.CachePolicy.Manual
-  alias ConfigCat.ConfigFetcher
 
   require ConfigCat.Constants, as: Constants
 
@@ -66,9 +65,6 @@ defmodule ConfigCat.CachePolicy do
 
   @typedoc false
   @type options :: [option]
-
-  @typedoc false
-  @type refresh_result :: :ok | ConfigFetcher.fetch_error()
 
   @typedoc "The polling mode"
   @opaque t :: Auto.t() | Lazy.t() | Manual.t()

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -86,12 +86,18 @@ defmodule ConfigCat.CachePolicy.Auto do
 
   @impl GenServer
   def handle_call(:force_refresh, _from, %State{} = state) do
-    case refresh(state) do
-      :ok ->
-        {:reply, :ok, state}
+    if state.offline do
+      message = "Client is in offline mode; it cannot initiate HTTP calls."
+      ConfigCatLogger.warn(message)
+      {:reply, {:error, message}, state}
+    else
+      case refresh(state) do
+        :ok ->
+          {:reply, :ok, state}
 
-      error ->
-        {:reply, error, state}
+        error ->
+          {:reply, error, state}
+      end
     end
   end
 

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -6,14 +6,12 @@ defmodule ConfigCat.CachePolicy.Behaviour do
   alias ConfigCat.Config
   alias ConfigCat.FetchTime
 
-  @type refresh_result :: CachePolicy.refresh_result()
-
   @callback get(ConfigCat.instance_id()) ::
               {:ok, Config.settings(), FetchTime.t()} | {:error, :not_found}
   @callback is_offline(ConfigCat.instance_id()) :: boolean()
   @callback set_offline(ConfigCat.instance_id()) :: :ok
   @callback set_online(ConfigCat.instance_id()) :: :ok
-  @callback force_refresh(ConfigCat.instance_id()) :: refresh_result()
+  @callback force_refresh(ConfigCat.instance_id()) :: ConfigCat.refresh_result()
 
   defmacro __using__(_opts) do
     quote location: :keep do

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -6,6 +6,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
   alias ConfigCat.Config
   alias ConfigCat.ConfigCache
   alias ConfigCat.ConfigEntry
+  alias ConfigCat.ConfigFetcher.FetchError
   alias ConfigCat.FetchTime
   alias ConfigCat.Hooks
 
@@ -86,7 +87,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
     Cache.get(state.instance_id)
   end
 
-  @spec refresh_config(State.t()) :: CachePolicy.refresh_result()
+  @spec refresh_config(State.t()) :: ConfigCat.refresh_result()
   def refresh_config(%State{} = state) do
     cached_entry =
       case cached_entry(state) do
@@ -98,10 +99,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
     case state.fetcher.fetch(state.instance_id, etag) do
       {:ok, :unchanged} ->
-        if cached_entry do
-          update_cache(state, ConfigEntry.refresh(cached_entry))
-        end
-
+        refresh_cached_entry(state, cached_entry)
         :ok
 
       {:ok, %ConfigEntry{} = entry} ->
@@ -113,9 +111,20 @@ defmodule ConfigCat.CachePolicy.Helpers do
 
         :ok
 
-      error ->
-        error
+      {:error, %FetchError{} = error} ->
+        unless error.transient? do
+          refresh_cached_entry(state, cached_entry)
+        end
+
+        {:error, Exception.message(error)}
     end
+  end
+
+  defp refresh_cached_entry(%State{} = _state, nil), do: :ok
+
+  defp refresh_cached_entry(%State{} = state, %ConfigEntry{} = entry) do
+    update_cache(state, ConfigEntry.refresh(entry))
+    :ok
   end
 
   defp update_cache(%State{} = state, %ConfigEntry{} = entry) do

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -63,8 +63,9 @@ defmodule ConfigCat.CachePolicy.Lazy do
   @impl GenServer
   def handle_call(:force_refresh, _from, %State{} = state) do
     if state.offline do
-      ConfigCatLogger.warn("Client is in offline mode; it cannot initiate HTTP calls.")
-      {:reply, :ok, state}
+      message = "Client is in offline mode; it cannot initiate HTTP calls."
+      ConfigCatLogger.warn(message)
+      {:reply, {:error, message}, state}
     else
       case refresh(state) do
         {:ok, new_state} ->

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -54,8 +54,9 @@ defmodule ConfigCat.CachePolicy.Manual do
   @impl GenServer
   def handle_call(:force_refresh, _from, %State{} = state) do
     if state.offline do
-      ConfigCatLogger.warn("Client is in offline mode; it cannot initiate HTTP calls.")
-      {:reply, :ok, state}
+      message = "Client is in offline mode; it cannot initiate HTTP calls."
+      ConfigCatLogger.warn(message)
+      {:reply, {:error, message}, state}
     else
       case Helpers.refresh_config(state) do
         :ok ->

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -48,7 +48,6 @@ defmodule ConfigCat.Client do
           | {:flag_overrides, OverrideDataSource.t()}
           | {:instance_id, ConfigCat.instance_id()}
   @type options :: [option]
-  @type refresh_result :: CachePolicy.refresh_result()
 
   @spec start_link(options()) :: GenServer.on_start()
   def start_link(options) do

--- a/lib/config_cat/config_entry.ex
+++ b/lib/config_cat/config_entry.ex
@@ -33,6 +33,11 @@ defmodule ConfigCat.ConfigEntry do
     }
   end
 
+  @spec refresh(t()) :: t()
+  def refresh(%__MODULE__{} = entry) do
+    %{entry | fetch_time_ms: FetchTime.now_ms()}
+  end
+
   @spec deserialize(String.t()) :: {:ok, t()} | {:error, String.t()}
   def deserialize(str) do
     with {:ok, [fetch_time_str, etag, raw_config]} <- parse(str),

--- a/test/config_cat/cache_policy/lazy_test.exs
+++ b/test/config_cat/cache_policy/lazy_test.exs
@@ -5,6 +5,7 @@ defmodule ConfigCat.CachePolicy.LazyTest do
 
   alias ConfigCat.CachePolicy
   alias ConfigCat.CachePolicy.Lazy
+  alias ConfigCat.FetchTime
 
   @policy CachePolicy.lazy(cache_expiry_seconds: 300)
 
@@ -90,12 +91,21 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       CachePolicy.force_refresh(instance_id)
     end
 
-    test "does not update config when server responds that the config hasn't changed" do
-      {:ok, instance_id} = start_cache_policy(@policy)
+    test "updates fetch time when server responds that the config hasn't changed", %{
+      entry: entry,
+      settings: settings
+    } do
+      entry = Map.update!(entry, :fetch_time_ms, &(&1 - 200))
+      {:ok, instance_id} = start_cache_policy(@policy, initial_entry: entry)
 
       expect_unchanged()
 
+      before = FetchTime.now_ms()
+
       assert :ok = CachePolicy.force_refresh(instance_id)
+
+      assert {:ok, ^settings, new_fetch_time_ms} = CachePolicy.get(instance_id)
+      assert before <= new_fetch_time_ms && new_fetch_time_ms <= FetchTime.now_ms()
     end
 
     @tag capture_log: true

--- a/test/config_cat/cache_policy/lazy_test.exs
+++ b/test/config_cat/cache_policy/lazy_test.exs
@@ -52,7 +52,7 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(entry)
-      CachePolicy.force_refresh(instance_id)
+      :ok = CachePolicy.force_refresh(instance_id)
 
       expect_not_refreshed()
       CachePolicy.get(instance_id)
@@ -64,7 +64,7 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       %{entry: old_entry} = make_old_entry()
 
       expect_refresh(old_entry)
-      CachePolicy.force_refresh(instance_id)
+      :ok = CachePolicy.force_refresh(instance_id)
 
       expect_refresh(entry)
       assert {:ok, settings, entry.fetch_time_ms} == CachePolicy.get(instance_id)
@@ -85,10 +85,10 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       {:ok, instance_id} = start_cache_policy(@policy)
 
       expect_refresh(entry)
-      CachePolicy.force_refresh(instance_id)
+      :ok = CachePolicy.force_refresh(instance_id)
 
       expect_refresh(entry)
-      CachePolicy.force_refresh(instance_id)
+      :ok = CachePolicy.force_refresh(instance_id)
     end
 
     test "updates fetch time when server responds that the config hasn't changed", %{
@@ -129,7 +129,7 @@ defmodule ConfigCat.CachePolicy.LazyTest do
       assert CachePolicy.is_offline(instance_id) == true
 
       expect_not_refreshed()
-      assert :ok = CachePolicy.force_refresh(instance_id)
+      assert {:error, _message} = CachePolicy.force_refresh(instance_id)
 
       assert :ok = CachePolicy.set_online(instance_id)
       assert CachePolicy.is_offline(instance_id) == false

--- a/test/config_cat/cache_policy/manual_test.exs
+++ b/test/config_cat/cache_policy/manual_test.exs
@@ -77,7 +77,7 @@ defmodule ConfigCat.CachePolicy.ManualTest do
       assert CachePolicy.is_offline(instance_id) == true
 
       expect_not_refreshed()
-      assert :ok = CachePolicy.force_refresh(instance_id)
+      assert {:error, _message} = CachePolicy.force_refresh(instance_id)
 
       assert :ok = CachePolicy.set_online(instance_id)
       assert CachePolicy.is_offline(instance_id) == false

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -5,6 +5,7 @@ defmodule ConfigCat.ConfigFetcherTest do
 
   alias ConfigCat.CacheControlConfigFetcher, as: ConfigFetcher
   alias ConfigCat.ConfigEntry
+  alias ConfigCat.ConfigFetcher.FetchError
   alias ConfigCat.FetchTime
   alias ConfigCat.Hooks
   alias ConfigCat.MockAPI
@@ -127,7 +128,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     MockAPI
     |> stub(:get, fn _url, _headers, _options -> {:ok, response} end)
 
-    assert {:error, ^response} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:error, %FetchError{reason: ^response}} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   @tag capture_log: true
@@ -139,7 +140,7 @@ defmodule ConfigCat.ConfigFetcherTest do
     MockAPI
     |> stub(:get, fn _url, _headers, _options -> {:error, error} end)
 
-    assert {:error, ^error} = ConfigFetcher.fetch(fetcher, nil)
+    assert {:error, %FetchError{reason: ^error}} = ConfigFetcher.fetch(fetcher, nil)
   end
 
   test "allows base URL to be configured" do

--- a/test/config_cat/hooks_test.exs
+++ b/test/config_cat/hooks_test.exs
@@ -132,7 +132,7 @@ defmodule ConfigCat.HooksTest do
 
     :ok = start_client(instance_id: instance_id)
 
-    ConfigCat.force_refresh(client: instance_id)
+    :ok = ConfigCat.force_refresh(client: instance_id)
 
     user = User.new("test@test1.com")
     value = ConfigCat.get_value("testStringKey", "", user, client: instance_id)
@@ -175,7 +175,7 @@ defmodule ConfigCat.HooksTest do
 
     :ok = start_client(instance_id: instance_id)
 
-    ConfigCat.force_refresh(client: instance_id)
+    :ok = ConfigCat.force_refresh(client: instance_id)
 
     assert "testValue" == ConfigCat.get_value("testStringKey", "", client: instance_id)
     assert "default" == ConfigCat.get_value("", "default", client: instance_id)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -50,15 +50,15 @@ defmodule ConfigCat.IntegrationTest do
   test "does not fetch config when offline mode is set" do
     {:ok, client} = start_config_cat(@sdk_key, offline: true)
 
-    assert ConfigCat.is_offline(client: client) == true
+    assert ConfigCat.is_offline(client: client)
 
-    :ok = ConfigCat.force_refresh(client: client)
+    {:error, _message} = ConfigCat.force_refresh(client: client)
 
     assert ConfigCat.get_value("keySampleText", "default value", client: client) ==
              "default value"
 
     :ok = ConfigCat.set_online(client: client)
-    assert ConfigCat.is_offline(client: client) == false
+    refute ConfigCat.is_offline(client: client)
 
     :ok = ConfigCat.force_refresh(client: client)
 
@@ -70,15 +70,14 @@ defmodule ConfigCat.IntegrationTest do
   test "handles errors from ConfigCat server" do
     {:ok, client} = start_config_cat("invalid_sdk_key")
 
-    {:error, response} = ConfigCat.force_refresh(client: client)
-    assert response.status_code == 403
+    assert {:error, _message} = ConfigCat.force_refresh(client: client)
   end
 
   @tag capture_log: true
   test "handles invalid base_url" do
     {:ok, client} = start_config_cat(@sdk_key, base_url: "https://invalidcdn.configcat.com")
 
-    assert {:error, %HTTPoison.Error{}} = ConfigCat.force_refresh(client: client)
+    assert {:error, _message} = ConfigCat.force_refresh(client: client)
   end
 
   @tag capture_log: true

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -9,6 +9,7 @@ defmodule ConfigCat.CachePolicyCase do
   alias ConfigCat.CachePolicy
   alias ConfigCat.Config
   alias ConfigCat.ConfigEntry
+  alias ConfigCat.ConfigFetcher.FetchError
   alias ConfigCat.Hooks
   alias ConfigCat.InMemoryCache
   alias ConfigCat.MockFetcher
@@ -112,10 +113,11 @@ defmodule ConfigCat.CachePolicyCase do
   @spec assert_returns_error(function()) :: true
   def assert_returns_error(force_refresh_fn) do
     response = %Response{status_code: 503}
+    error = FetchError.exception(reason: response, transient?: true)
 
     MockFetcher
-    |> stub(:fetch, fn _id, _etag -> {:error, response} end)
+    |> stub(:fetch, fn _id, _etag -> {:error, error} end)
 
-    assert {:error, ^response} = force_refresh_fn.()
+    assert {:error, _message} = force_refresh_fn.()
   end
 end


### PR DESCRIPTION
### Describe the purpose of your pull request

- Refresh the fetch time of the cache entry when a fetch returns 304
- Refresh the fetch time of the cache entry when a fetch returns a non-transient error (to reduce the load on the server)
- Make log messages consistent with other platforms

As I was doing this work, I realized that we were leaking HTTPoison.Error and HTTPPoison.Response structs out to callers of `force_refresh`. Instead, we now return an `{:error, message}` tuple.

I also noticed that, in the Ruby version, `force_refresh` returns an error message when offline which the Elixir version wasn't, so I fixed that.

I also noticed that the Ruby version does not return an error from force_refresh if there is a previously cached result. That doesn't seem right to me, so I did not make that change here.

**NOTE:** This is built on top of #100 and the base branch has been set accordingly.

### Related issues (only if applicable)

https://trello.com/c/mJ7o5g8v/8-consistent-fetch-logic-elixir

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
