### PR TITLE
✨ Max init wait time seconds

### DIFF
--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -47,7 +47,8 @@ defmodule ConfigCat.CachePolicy do
 
   @typedoc "Options for auto-polling mode."
   @type auto_options :: [
-          {:poll_interval_seconds, pos_integer()}
+          {:max_init_wait_time_seconds, non_neg_integer()}
+          | {:poll_interval_seconds, pos_integer()}
         ]
 
   @typedoc "Options for lazy-polling mode."
@@ -74,6 +75,14 @@ defmodule ConfigCat.CachePolicy do
 
   The *ConfigCat SDK* downloads the latest values and stores them
   automatically on a regular schedule.
+
+  Use the `max_init_wait_time_seconds` option to set the maximum waiting time
+  between initialization and the first config acquisition. Defaults to 5 seconds
+  if not specified.
+
+  ```elixir
+  ConfigCat.CachePolicy.auto(max_init_wait_time_seconds: 5)
+  ```
 
   Use the `poll_interval_seconds` option to change the
   polling interval. Defaults to 60 seconds if not specified.

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -13,6 +13,26 @@ defmodule ConfigCat.CachePolicy.Auto do
 
   require ConfigCat.ConfigCatLogger, as: ConfigCatLogger
 
+  defmodule LocalState do
+    @moduledoc false
+    use TypedStruct
+
+    typedstruct enforce: true do
+      field :callers, [GenServer.from()], default: []
+      field :initialized?, boolean(), default: false
+    end
+
+    @spec add_caller(t(), GenServer.from()) :: t()
+    def add_caller(%__MODULE__{} = state, caller) do
+      %{state | callers: [caller | state.callers]}
+    end
+
+    @spec be_initialized(t()) :: t()
+    def be_initialized(%__MODULE__{} = state) do
+      %{state | callers: [], initialized?: true}
+    end
+  end
+
   @default_max_init_wait_time_seconds 5
   @default_poll_interval_seconds 60
 
@@ -48,16 +68,37 @@ defmodule ConfigCat.CachePolicy.Auto do
   @impl GenServer
   def init(%State{} = state) do
     Logger.metadata(instance_id: state.instance_id)
-    {:ok, state, {:continue, :initial_fetch}}
+    state = Map.put(state, :policy_state, %LocalState{})
+
+    Process.send_after(self(), :init_timeout, state.policy_options.max_init_wait_time_ms)
+
+    {:ok, state, {:continue, :start_polling}}
+  end
+
+  defguardp initialized?(state) when state.policy_state.initialized?
+
+  @impl GenServer
+  def handle_continue(:start_polling, %State{} = state) do
+    new_state =
+      if state.offline do
+        be_initialized(state)
+      else
+        schedule_initial_refresh(state)
+      end
+
+    {:noreply, new_state}
   end
 
   @impl GenServer
-  def handle_continue(:initial_fetch, %State{} = state) do
-    unless state.offline do
-      initial_refresh(state)
-    end
+  def handle_info(:be_initialized, %State{} = state) do
+    new_state = be_initialized(state)
+    {:noreply, new_state}
+  end
 
-    {:noreply, state}
+  @impl GenServer
+  def handle_info(:init_timeout, %State{} = state) do
+    new_state = be_initialized(state)
+    {:noreply, new_state}
   end
 
   @impl GenServer
@@ -69,10 +110,17 @@ defmodule ConfigCat.CachePolicy.Auto do
         Logger.metadata(instance_id: state.instance_id)
         refresh(state)
         schedule_next_refresh(state, pid)
+        send(pid, :be_initialized)
       end)
     end
 
     {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_call(:get, from, %State{} = state) when not initialized?(state) do
+    new_state = State.update_policy_state(state, &LocalState.add_caller(&1, from))
+    {:noreply, new_state}
   end
 
   @impl GenServer
@@ -92,8 +140,11 @@ defmodule ConfigCat.CachePolicy.Auto do
 
   @impl GenServer
   def handle_call(:set_online, _from, %State{} = state) do
-    new_state = State.set_online(state)
-    initial_refresh(new_state)
+    new_state =
+      state
+      |> State.set_online()
+      |> schedule_initial_refresh()
+
     {:reply, :ok, new_state}
   end
 
@@ -114,7 +165,7 @@ defmodule ConfigCat.CachePolicy.Auto do
     end
   end
 
-  defp initial_refresh(%State{} = state) do
+  defp schedule_initial_refresh(%State{} = state) do
     interval_ms = state.policy_options.poll_interval_ms
 
     delay_ms =
@@ -128,16 +179,29 @@ defmodule ConfigCat.CachePolicy.Auto do
       end
 
     if delay_ms == 0 do
-      refresh(state)
-      Helpers.on_client_ready(state)
-      schedule_next_refresh(state)
+      send(self(), :polled_refresh)
+      state
     else
-      Helpers.on_client_ready(state)
       Process.send_after(self(), :polled_refresh, delay_ms)
+      be_initialized(state)
     end
   end
 
-  defp schedule_next_refresh(%State{} = state, pid \\ self()) do
+  defp be_initialized(%State{} = state) when initialized?(state), do: state
+
+  defp be_initialized(%State{} = state) do
+    settings = Helpers.cached_settings(state)
+
+    for caller <- state.policy_state.callers do
+      GenServer.reply(caller, settings)
+    end
+
+    Helpers.on_client_ready(state)
+
+    State.update_policy_state(state, &LocalState.be_initialized/1)
+  end
+
+  defp schedule_next_refresh(%State{} = state, pid) do
     interval_ms = state.policy_options.poll_interval_ms
 
     Process.send_after(pid, :polled_refresh, interval_ms)

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -57,12 +57,19 @@ defmodule ConfigCat.CachePolicy.Auto do
 
     options =
       [
-        max_init_wait_time_ms: max(max_init_wait_time_seconds, 0) * 1000,
-        poll_interval_ms: max(poll_interval_seconds, 1) * 1000
+        max_init_wait_time_ms: rounded_ms(max_init_wait_time_seconds, 0),
+        poll_interval_ms: rounded_ms(poll_interval_seconds, 1)
       ]
       |> Keyword.merge(options)
 
     struct(__MODULE__, options)
+  end
+
+  defp rounded_ms(seconds, min_value) do
+    seconds
+    |> max(min_value)
+    |> Kernel.*(1000)
+    |> round
   end
 
   @impl GenServer

--- a/lib/config_cat/cache_policy/helpers.ex
+++ b/lib/config_cat/cache_policy/helpers.ex
@@ -19,6 +19,7 @@ defmodule ConfigCat.CachePolicy.Helpers do
       field :instance_id, ConfigCat.instance_id()
       field :offline, boolean()
       field :policy_options, map(), default: %{}
+      field :policy_state, map(), default: %{}
     end
 
     @spec new(Keyword.t()) :: t()
@@ -45,6 +46,11 @@ defmodule ConfigCat.CachePolicy.Helpers do
     @spec set_online(t()) :: t()
     def set_online(%__MODULE__{} = state) do
       %{state | offline: false}
+    end
+
+    @spec update_policy_state(t(), (map() -> map())) :: t()
+    def update_policy_state(%__MODULE__{} = state, updater) do
+      Map.update!(state, :policy_state, updater)
     end
   end
 

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -17,15 +17,24 @@ defmodule ConfigCat.CachePolicy.AutoTest do
 
   describe "creation" do
     test "returns a struct with the expected polling mode and options" do
-      seconds = 123
-      policy = CachePolicy.auto(poll_interval_seconds: seconds)
+      policy = CachePolicy.auto(max_init_wait_time_seconds: 123, poll_interval_seconds: 456)
 
-      assert policy == %Auto{poll_interval_ms: seconds * 1000, mode: "a"}
+      assert policy == %Auto{max_init_wait_time_ms: 123_000, poll_interval_ms: 456_000, mode: "a"}
+    end
+
+    test "provides a default max init wait time interval" do
+      policy = CachePolicy.auto()
+      assert policy.max_init_wait_time_ms == 5_000
     end
 
     test "provides a default poll interval" do
       policy = CachePolicy.auto()
       assert policy.poll_interval_ms == 60_000
+    end
+
+    test "enforces a minimum max init wait time interval" do
+      policy = CachePolicy.auto(max_init_wait_time_seconds: -1)
+      assert policy.max_init_wait_time_ms == 0
     end
 
     test "enforces a minimum poll interval" do


### PR DESCRIPTION
**NOTE:** This is built on top of #101 and the base branch has been set accordingly. I will rebase this once that PR has been merged.

### Describe the purpose of your pull request

Adds the auto-poll option `max_init_wait_time_seconds`.

In order to make this work correctly, I had to significantly modify how the Auto policy worked. Now, it always fetches in the background.

When a caller calls `get` before the initial fetch is completed, the caller is added to a list and we use `{:noreply, ...}` to block the caller while still allowing the GenServer to keep working.

Once the initial fetch completes or times out, all pending callers are unblocked with `GenServer.reply`.

See [my blog post](https://blog.sequin.io/genserver-reply-dont-call-us-well-call-you/) for more details on this technique.

### Related issues (only if applicable)

https://trello.com/c/ikVMZeSa/14-maxinitwaittimeseconds

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
