### PR TITLE
⚡️ Respond to all queued fetch requests with single response

### DIFF
--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -92,7 +92,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       assert {:ok, old_settings, old_entry.fetch_time_ms} == CachePolicy.get(instance_id)
       elapsed_ms = FetchTime.now_ms() - before
 
-      assert wait_time_ms < elapsed_ms && elapsed_ms < wait_time_ms * 2
+      assert wait_time_ms <= elapsed_ms && elapsed_ms <= wait_time_ms * 2
     end
 
     test "doesn't refresh between poll intervals", %{entry: entry} do


### PR DESCRIPTION
**NOTE:** This is built on top of #102 and the base branch has been set accordingly. I will rebase on latest main before merging.

### Describe the purpose of your pull request

When performing a fetch, queue up any new requests and then respond to all of the fetches with the result of the pending fetch.

This avoids making multiple consecutive fetch requests to the server.

Uses a technique I describe in [this blog post](https://blog.sequin.io/genserver-reply-dont-call-us-well-call-you/](https://blog.sequin.io/genserver-reply-dont-call-us-well-call-you/) along with a list of pending callers in the GenServer state.

### Related issues (only if applicable)

https://trello.com/c/H6PU0SG0/15-only-one-config-json-download-at-a-time

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
