### PR TITLE
🧑‍💻 Make it easier to use multiple ConfigCat instances

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -23,28 +23,9 @@ defmodule ConfigCat do
   end
   ```
 
-  If you need to run more than one instance of `ConfigCat`, you can add multiple
-  `ConfigCat` children. You will need to give `ConfigCat` a unique `name` option
-  for each, as well as using `Supervisor.child_spec/2` to provide a unique `id`
-  for each instance.
-
-  ```elixir
-  # lib/my_app/application.ex
-  def start(_type, _args) do
-    children = [
-      # ... other children ...
-      Supervisor.child_spec({ConfigCat, [sdk_key: "sdk_key_1", name: :first]}, id: :config_cat_1),
-      Supervisor.child_spec({ConfigCat, [sdk_key: "sdk_key_2", name: :second]}, id: :config_cat_2),
-    ]
-
-    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-  ```
-
   ### Options
 
-  `ConfigCat` takes a number of other keyword arguments:
+  `ConfigCat` takes a number of keyword arguments:
 
   - `sdk_key`: **REQUIRED** The SDK key for accessing your ConfigCat settings.
     Go to the [Connect your application](https://app.configcat.com/sdkkey) tab
@@ -82,8 +63,8 @@ defmodule ConfigCat do
     {ConfigCat, [sdk_key: "YOUR SDK KEY", cache_policy: ConfigCat.CachePolicy.manual()]}
     ```
 
-  - `connect_timeout_milliseconds`: **OPTIONAL** timeout for establishing a TCP or SSL connection,
-    in milliseconds. Default is 8000.
+  - `connect_timeout_milliseconds`: **OPTIONAL** timeout for establishing a TCP
+    or SSL connection, in milliseconds. Default is 8000.
 
     ```elixir
     {ConfigCat, [sdk_key: "YOUR SDK KEY", connect_timeout_milliseconds: 8000]}
@@ -127,7 +108,7 @@ defmodule ConfigCat do
     Defaults to `ConfigCat`.  Must be provided if you need to run more than one
     instance of `ConfigCat` in the same application. If you provide a `name`,
     you must then pass that name to all of the API functions using the `client`
-    option.
+    option. See `Multiple Instances` below.
 
     ```elixir
     {ConfigCat, [sdk_key: "YOUR SDK KEY", name: :unique_name]}
@@ -144,12 +125,67 @@ defmodule ConfigCat do
     {ConfigCat, [sdk_key: "YOUR SDK KEY", offline: true]}
     ```
 
-  - `read_timeout_milliseconds`: **OPTIONAL** timeout for receiving an HTTP response from
-    the socket, in milliseconds. Default is 5000.
+  - `read_timeout_milliseconds`: **OPTIONAL** timeout for receiving an HTTP
+    response from the socket, in milliseconds. Default is 5000.
 
     ```elixir
     {ConfigCat, [sdk_key: "YOUR SDK KEY", read_timeout_milliseconds: 5000]}
     ```
+
+  ### Multiple Instances
+
+  If you need to run more than one instance of `ConfigCat`, there are two ways
+  you can do it.
+
+  #### Module-Based
+
+  You can create a module that `use`s `ConfigCat` and then call the ConfigCat
+  API functions on that module. This is the recommended option, as it makes the
+  calling code a bit clearer and simpler.
+
+  ```elixir
+  # lib/my_app/first_flags.ex
+  defmodule MyApp.FirstFlags do
+    use ConfigCat
+  end
+
+  # lib/my_app/second_flags.ex
+  defmodule MyApp.SecondFlags do
+    use ConfigCat
+  end
+
+  # Calling code:
+  FirstFlags.get_value("someKey", "default value")
+  SecondFlags.get_value("otherKey", "other default")
+  ```
+
+  #### Explicit Client
+
+  If you prefer not to use the module-based solution, you can instead add
+  multiple `ConfigCat` children to your application's supervision tree. You will
+  need to give `ConfigCat` a unique `name` option for each, as well as using
+  `Supervisor.child_spec/2` to provide a unique `id` for each instance.
+
+  When calling the ConfigCat API functions, you'll pass a `client:` keyword
+  argument with the unique `name` you gave to that instance.
+
+  ```elixir
+  # lib/my_app/application.ex
+  def start(_type, _args) do
+    children = [
+      # ... other children ...
+      Supervisor.child_spec({ConfigCat, [sdk_key: "sdk_key_1", name: :first]}, id: :config_cat_1),
+      Supervisor.child_spec({ConfigCat, [sdk_key: "sdk_key_2", name: :second]}, id: :config_cat_2),
+    ]
+
+    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+  # Calling code:
+  ConfigCat.get_value("someKey", "default value", client: :first)
+  ConfigCat.get_value("otherKey", "other default", client: :second)
+  ```
 
   ## Use the API
 
@@ -526,5 +562,85 @@ defmodule ConfigCat do
     options
     |> Keyword.get(:client, __MODULE__)
     |> Client.via_tuple()
+  end
+
+  defmacro __using__(_opts) do
+    quote do
+      @spec child_spec(ConfigCat.options()) :: Supervisor.child_spec()
+      def child_spec(options) do
+        options = Keyword.put(options, :name, __MODULE__)
+        Supervisor.child_spec({ConfigCat, options}, id: __MODULE__)
+      end
+
+      @spec get_all_keys :: [ConfigCat.key()]
+      def get_all_keys do
+        ConfigCat.get_all_keys(client: __MODULE__)
+      end
+
+      @spec get_value(ConfigCat.key(), ConfigCat.value(), ConfigCat.User.t() | nil) ::
+              ConfigCat.value()
+      def get_value(key, default_value, user \\ nil) do
+        ConfigCat.get_value(key, default_value, user, client: __MODULE__)
+      end
+
+      @spec get_value_details(ConfigCat.key(), ConfigCat.value(), ConfigCat.User.t() | nil) ::
+              ConfigCat.EvaluationDetails.t()
+      def get_value_details(key, default_value, user \\ nil) do
+        ConfigCat.get_value_details(key, default_value, user, client: __MODULE__)
+      end
+
+      @spec get_all_value_details(ConfigCat.User.t() | nil) :: [EvaluationDetails.t()]
+      def get_all_value_details(user \\ nil) do
+        ConfigCat.get_all_value_details(user, client: __MODULE__)
+      end
+
+      @spec get_key_and_value(ConfigCat.variation_id()) ::
+              {ConfigCat.key(), ConfigCat.value()} | nil
+      def get_key_and_value(variation_id) do
+        ConfigCat.get_key_and_value(variation_id, client: __MODULE__)
+      end
+
+      @spec get_all_values(ConfigCat.User.t() | nil) :: %{ConfigCat.key() => ConfigCat.value()}
+      def get_all_values(user \\ nil) do
+        ConfigCat.get_all_values(user, client: __MODULE__)
+      end
+
+      @spec force_refresh :: ConfigCat.refresh_result()
+      def force_refresh do
+        ConfigCat.force_refresh(client: __MODULE__)
+      end
+
+      @spec set_default_user(ConfigCat.User.t()) :: :ok
+      def set_default_user(user) do
+        ConfigCat.set_default_user(user, client: __MODULE__)
+      end
+
+      @spec clear_default_user :: :ok
+      def clear_default_user do
+        ConfigCat.clear_default_user(client: __MODULE__)
+      end
+
+      @spec set_online :: :ok
+      def set_online do
+        ConfigCat.set_online(client: __MODULE__)
+      end
+
+      @spec set_offline :: :ok
+      def set_offline do
+        ConfigCat.set_offline(client: __MODULE__)
+      end
+
+      @spec is_offline :: boolean()
+      # We should consider renaming this throughout the codebase in a follow-up
+      # credo:disable-for-next-line Credo.Check.Readability.PredicateFunctionNames
+      def is_offline do
+        ConfigCat.is_offline(client: __MODULE__)
+      end
+
+      @spec hooks :: ConfigCat.Hooks.t()
+      def hooks do
+        ConfigCat.hooks(client: __MODULE__)
+      end
+    end
   end
 end

--- a/samples/multi/lib/multi.ex
+++ b/samples/multi/lib/multi.ex
@@ -19,12 +19,12 @@ defmodule Multi do
 
   defmodule First do
     @moduledoc false
-    use ConfigCat
+    use ConfigCat, sdk_key: "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"
   end
 
   defmodule Second do
     @moduledoc false
-    use ConfigCat
+    use ConfigCat, sdk_key: "PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ"
   end
 
   def start_link(_options) do

--- a/samples/multi/lib/multi.ex
+++ b/samples/multi/lib/multi.ex
@@ -17,6 +17,16 @@ defmodule Multi do
 
   alias ConfigCat.User
 
+  defmodule First do
+    @moduledoc false
+    use ConfigCat
+  end
+
+  defmodule Second do
+    @moduledoc false
+    use ConfigCat
+  end
+
   def start_link(_options) do
     GenServer.start_link(__MODULE__, [])
   end
@@ -32,41 +42,36 @@ defmodule Multi do
   defp run_first_examples do
     # 1. As the passed User's country is Hungary this will print 'Dog'
     my_setting_value =
-      ConfigCat.get_value("keySampleText", "default value", User.new("key", country: "Hungary"),
-        client: :first
-      )
+      First.get_value("keySampleText", "default value", User.new("key", country: "Hungary"))
 
     print("keySampleText", my_setting_value)
 
     # 2. As the passed User's custom attribute - SubscriptionType - is unlimited this will print 'Lion'
     my_setting_value =
-      ConfigCat.get_value(
+      First.get_value(
         "keySampleText",
         "default value",
-        User.new("key", custom: %{"SubscriptionType" => "unlimited"}),
-        client: :first
+        User.new("key", custom: %{"SubscriptionType" => "unlimited"})
       )
 
     print("keySampleText", my_setting_value)
 
     # 3/a. As the passed User doesn't fill in any rules, this will serve 'Falcon' or 'Horse'.
-    my_setting_value =
-      ConfigCat.get_value("keySampleText", "default value", User.new("key"), client: :first)
+    my_setting_value = First.get_value("keySampleText", "default value", User.new("key"))
 
     print("keySampleText", my_setting_value)
 
     # 3/b. As this is the same user from 3/a., this will print the same value as the previous one ('Falcon' or 'Horse')
-    my_setting_value =
-      ConfigCat.get_value("keySampleText", "default value", User.new("key"), client: :first)
+    my_setting_value = First.get_value("keySampleText", "default value", User.new("key"))
 
     print("keySampleText", my_setting_value)
 
     # 4. As we don't pass an User object to this call, this will print the setting's default value - 'Cat'
-    my_setting_value = ConfigCat.get_value("keySampleText", "default value", client: :first)
+    my_setting_value = First.get_value("keySampleText", "default value")
     print("keySampleText", my_setting_value)
 
     # 'myKeyNotExists' setting doesn't exist in the project configuration and the client returns default value ('default value')
-    my_setting_value = ConfigCat.get_value("myKeyNotExists", "default value", client: :first)
+    my_setting_value = First.get_value("myKeyNotExists", "default value")
     print("myKeyNotExists", my_setting_value)
   end
 
@@ -77,10 +82,10 @@ defmodule Multi do
         custom: %{version: "1.0.0"}
       )
 
-    value = ConfigCat.get_value("isPOCFeatureEnabled", "default value", user, client: :second)
+    value = Second.get_value("isPOCFeatureEnabled", "default value", user)
     print("isPOCFeatureEnabled", value)
 
-    value = ConfigCat.get_value("isAwesomeFeatureEnabled", "default value", client: :second)
+    value = Second.get_value("isAwesomeFeatureEnabled", "default value")
     print("isAwesomeFeatureEnabled", value)
   end
 

--- a/samples/multi/lib/multi/application.ex
+++ b/samples/multi/lib/multi/application.ex
@@ -15,8 +15,8 @@ defmodule Multi.Application do
     Logger.configure(level: :debug)
 
     children = [
-      Supervisor.child_spec({ConfigCat, [sdk_key: @sdk_key_1, name: :first]}, id: :config_cat_1),
-      Supervisor.child_spec({ConfigCat, [sdk_key: @sdk_key_2, name: :second]}, id: :config_cat_2),
+      {Multi.First, sdk_key: @sdk_key_1},
+      {Multi.Second, sdk_key: @sdk_key_2},
       Multi
     ]
 

--- a/samples/multi/lib/multi/application.ex
+++ b/samples/multi/lib/multi/application.ex
@@ -5,9 +5,6 @@ defmodule Multi.Application do
 
   require Logger
 
-  @sdk_key_1 "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"
-  @sdk_key_2 "PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ"
-
   @impl Application
   def start(_type, _args) do
     # Debug level logging helps to inspect the feature flag evaluation process.
@@ -15,8 +12,8 @@ defmodule Multi.Application do
     Logger.configure(level: :debug)
 
     children = [
-      {Multi.First, sdk_key: @sdk_key_1},
-      {Multi.Second, sdk_key: @sdk_key_2},
+      Multi.First,
+      Multi.Second,
       Multi
     ]
 

--- a/test/using_block_test.exs
+++ b/test/using_block_test.exs
@@ -1,0 +1,17 @@
+defmodule ConfigCat.UsingBlockTest do
+  use ExUnit.Case, async: true
+
+  defmodule CustomModule do
+    @moduledoc false
+    use ConfigCat, sdk_key: "PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA"
+  end
+
+  test "can call API through using block" do
+    _pid = start_supervised!(CustomModule)
+
+    :ok = CustomModule.force_refresh()
+
+    assert CustomModule.get_value("keySampleText", "default value") ==
+             "This text came from ConfigCat"
+  end
+end


### PR DESCRIPTION
**NOTE:** This is based on #103 and the base branch has been set accordingly. I'll rebase on latest main before merging this PR.

### Describe the purpose of your pull request

Add a `__using__` macro to `ConfigCat` to allow client applications to define their own feature flag modules with `use ConfigCat`. The module's name is automatically used as the instance_id for that instance of ConfigCat.

ConfigCat options can be passed in either the `use ConfigCat` declaration or in the child specification used in the application's supervisor. Supervisor-provided options take precedence over those provided to the `use ConfigCat` declaration.

See the updated documentation and `multi` example for details.

### Related issues (only if applicable)

Closes #39.
https://trello.com/c/OSbPcFhd/12-make-it-more-convenient-to-use-multiple-configcat-instances

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
