### PR TITLE
💥 Rename is_offline -> offline?

### DIFF
--- a/lib/config_cat.ex
+++ b/lib/config_cat.ex
@@ -554,11 +554,11 @@ defmodule ConfigCat do
     `client: :unique_name` option, specifying the name you configured for the
     instance you want to access.
   """
-  @spec is_offline([api_option()]) :: boolean()
-  def is_offline(options \\ []) do
+  @spec offline?([api_option()]) :: boolean()
+  def offline?(options \\ []) do
     options
     |> client()
-    |> GenServer.call(:is_offline, Constants.fetch_timeout())
+    |> GenServer.call(:offline?, Constants.fetch_timeout())
   end
 
   @doc """
@@ -653,11 +653,9 @@ defmodule ConfigCat do
         ConfigCat.set_offline(client: @client)
       end
 
-      @spec is_offline :: boolean()
-      # We should consider renaming this throughout the codebase in a follow-up
-      # credo:disable-for-next-line Credo.Check.Readability.PredicateFunctionNames
-      def is_offline do
-        ConfigCat.is_offline(client: @client)
+      @spec offline? :: boolean()
+      def offline? do
+        ConfigCat.offline?(client: @client)
       end
 
       @spec hooks :: ConfigCat.Hooks.t()

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -148,10 +148,10 @@ defmodule ConfigCat.CachePolicy do
   end
 
   @impl Behaviour
-  def is_offline(instance_id) do
+  def offline?(instance_id) do
     instance_id
     |> via_tuple()
-    |> GenServer.call(:is_offline, Constants.fetch_timeout())
+    |> GenServer.call(:offline?, Constants.fetch_timeout())
   end
 
   @impl Behaviour

--- a/lib/config_cat/cache_policy/auto.ex
+++ b/lib/config_cat/cache_policy/auto.ex
@@ -143,7 +143,7 @@ defmodule ConfigCat.CachePolicy.Auto do
   end
 
   @impl GenServer
-  def handle_call(:is_offline, _from, %State{} = state) do
+  def handle_call(:offline?, _from, %State{} = state) do
     {:reply, state.offline, state}
   end
 

--- a/lib/config_cat/cache_policy/behaviour.ex
+++ b/lib/config_cat/cache_policy/behaviour.ex
@@ -8,7 +8,7 @@ defmodule ConfigCat.CachePolicy.Behaviour do
 
   @callback get(ConfigCat.instance_id()) ::
               {:ok, Config.settings(), FetchTime.t()} | {:error, :not_found}
-  @callback is_offline(ConfigCat.instance_id()) :: boolean()
+  @callback offline?(ConfigCat.instance_id()) :: boolean()
   @callback set_offline(ConfigCat.instance_id()) :: :ok
   @callback set_online(ConfigCat.instance_id()) :: :ok
   @callback force_refresh(ConfigCat.instance_id()) :: ConfigCat.refresh_result()

--- a/lib/config_cat/cache_policy/lazy.ex
+++ b/lib/config_cat/cache_policy/lazy.ex
@@ -46,7 +46,7 @@ defmodule ConfigCat.CachePolicy.Lazy do
   end
 
   @impl GenServer
-  def handle_call(:is_offline, _from, %State{} = state) do
+  def handle_call(:offline?, _from, %State{} = state) do
     {:reply, state.offline, state}
   end
 

--- a/lib/config_cat/cache_policy/manual.ex
+++ b/lib/config_cat/cache_policy/manual.ex
@@ -37,7 +37,7 @@ defmodule ConfigCat.CachePolicy.Manual do
   end
 
   @impl GenServer
-  def handle_call(:is_offline, _from, %State{} = state) do
+  def handle_call(:offline?, _from, %State{} = state) do
     {:reply, state.offline, state}
   end
 

--- a/lib/config_cat/cache_policy/null.ex
+++ b/lib/config_cat/cache_policy/null.ex
@@ -16,7 +16,7 @@ defmodule ConfigCat.CachePolicy.Null do
   end
 
   @impl Behaviour
-  def is_offline(_instance_id) do
+  def offline?(_instance_id) do
     true
   end
 

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -164,10 +164,10 @@ defmodule ConfigCat.Client do
   end
 
   @impl GenServer
-  def handle_call(:is_offline, _from, %State{} = state) do
+  def handle_call(:offline?, _from, %State{} = state) do
     %{cache_policy: policy, instance_id: instance_id} = state
 
-    result = policy.is_offline(instance_id)
+    result = policy.offline?(instance_id)
     {:reply, result, state}
   end
 

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -237,10 +237,12 @@ defmodule ConfigCat.CachePolicy.AutoTest do
 
       assert {:ok, old_settings, old_entry.fetch_time_ms} == CachePolicy.get(instance_id)
 
-      expect_refresh(entry)
+      expect_refresh(entry, self())
 
       assert :ok = CachePolicy.set_online(instance_id)
       refute CachePolicy.offline?(instance_id)
+
+      assert_receive :fetch_complete
 
       assert {:ok, settings, entry.fetch_time_ms} == CachePolicy.get(instance_id)
     end

--- a/test/config_cat/cache_policy/auto_test.exs
+++ b/test/config_cat/cache_policy/auto_test.exs
@@ -226,11 +226,11 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       expect_refresh(old_entry)
       {:ok, instance_id} = start_cache_policy(policy)
 
-      refute CachePolicy.is_offline(instance_id)
+      refute CachePolicy.offline?(instance_id)
       assert {:ok, old_settings, old_entry.fetch_time_ms} == CachePolicy.get(instance_id)
 
       assert :ok = CachePolicy.set_offline(instance_id)
-      assert CachePolicy.is_offline(instance_id)
+      assert CachePolicy.offline?(instance_id)
 
       expect_not_refreshed()
       wait_for_poll(policy)
@@ -240,7 +240,7 @@ defmodule ConfigCat.CachePolicy.AutoTest do
       expect_refresh(entry)
 
       assert :ok = CachePolicy.set_online(instance_id)
-      refute CachePolicy.is_offline(instance_id)
+      refute CachePolicy.offline?(instance_id)
 
       assert {:ok, settings, entry.fetch_time_ms} == CachePolicy.get(instance_id)
     end

--- a/test/config_cat/cache_policy/lazy_test.exs
+++ b/test/config_cat/cache_policy/lazy_test.exs
@@ -119,19 +119,19 @@ defmodule ConfigCat.CachePolicy.LazyTest do
     @tag capture_log: true
     test "does not fetch config when offline mode is set", %{entry: entry} do
       {:ok, instance_id} = start_cache_policy(@policy)
-      assert CachePolicy.is_offline(instance_id) == false
+      assert CachePolicy.offline?(instance_id) == false
 
       expect_refresh(entry)
       assert :ok = CachePolicy.force_refresh(instance_id)
 
       assert :ok = CachePolicy.set_offline(instance_id)
-      assert CachePolicy.is_offline(instance_id) == true
+      assert CachePolicy.offline?(instance_id) == true
 
       expect_not_refreshed()
       assert {:error, _message} = CachePolicy.force_refresh(instance_id)
 
       assert :ok = CachePolicy.set_online(instance_id)
-      assert CachePolicy.is_offline(instance_id) == false
+      assert CachePolicy.offline?(instance_id) == false
 
       expect_refresh(entry)
       assert :ok = CachePolicy.force_refresh(instance_id)

--- a/test/config_cat/cache_policy/manual_test.exs
+++ b/test/config_cat/cache_policy/manual_test.exs
@@ -68,19 +68,19 @@ defmodule ConfigCat.CachePolicy.ManualTest do
     @tag capture_log: true
     test "does not fetch config when offline mode is set", %{entry: entry} do
       {:ok, instance_id} = start_cache_policy(@policy)
-      assert CachePolicy.is_offline(instance_id) == false
+      assert CachePolicy.offline?(instance_id) == false
 
       expect_refresh(entry)
       assert :ok = CachePolicy.force_refresh(instance_id)
 
       assert :ok = CachePolicy.set_offline(instance_id)
-      assert CachePolicy.is_offline(instance_id) == true
+      assert CachePolicy.offline?(instance_id) == true
 
       expect_not_refreshed()
       assert {:error, _message} = CachePolicy.force_refresh(instance_id)
 
       assert :ok = CachePolicy.set_online(instance_id)
-      assert CachePolicy.is_offline(instance_id) == false
+      assert CachePolicy.offline?(instance_id) == false
 
       expect_refresh(entry)
       assert :ok = CachePolicy.force_refresh(instance_id)

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -50,7 +50,7 @@ defmodule ConfigCat.IntegrationTest do
   test "does not fetch config when offline mode is set" do
     {:ok, client} = start_config_cat(@sdk_key, offline: true)
 
-    assert ConfigCat.is_offline(client: client)
+    assert ConfigCat.offline?(client: client)
 
     {:error, _message} = ConfigCat.force_refresh(client: client)
 
@@ -58,7 +58,7 @@ defmodule ConfigCat.IntegrationTest do
              "default value"
 
     :ok = ConfigCat.set_online(client: client)
-    refute ConfigCat.is_offline(client: client)
+    refute ConfigCat.offline?(client: client)
 
     :ok = ConfigCat.force_refresh(client: client)
 

--- a/test/support/cache_policy_case.ex
+++ b/test/support/cache_policy_case.ex
@@ -95,10 +95,11 @@ defmodule ConfigCat.CachePolicyCase do
     {:ok, cache_key}
   end
 
-  @spec expect_refresh(ConfigEntry.t()) :: Mox.t()
-  def expect_refresh(entry) do
+  @spec expect_refresh(ConfigEntry.t(), pid() | nil) :: Mox.t()
+  def expect_refresh(entry, test_pid \\ nil) do
     MockFetcher
     |> expect(:fetch, fn _id, _etag ->
+      if test_pid, do: send(test_pid, :fetch_complete)
       {:ok, entry}
     end)
   end


### PR DESCRIPTION
### Describe the purpose of your pull request

Rename `is_offline` to `offline?` to better match Elixir conventions. I note that the Ruby SDK also follows this naming convention.

### Related issues (only if applicable)

Follow-up to #104, where a Credo rule made me aware of this issue.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
