### PR TITLE
✨ Ensure that only one instance can use the same SDK key

### DIFF
--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -16,6 +16,16 @@ defmodule ConfigCat.IntegrationTest do
     |> assert_sdk_key_required()
   end
 
+  test "raises error when starting another instance with the same SDK key" do
+    {:ok, _} = start_config_cat(@sdk_key, name: :original)
+
+    assert {:error, {{:EXIT, {error, _stacktrace}}, _spec}} =
+             start_config_cat(@sdk_key, name: :duplicate)
+
+    assert %ArgumentError{message: message} = error
+    assert message =~ ~r/existing ConfigCat instance/
+  end
+
   test "fetches config" do
     {:ok, client} = start_config_cat(@sdk_key)
 
@@ -104,7 +114,7 @@ defmodule ConfigCat.IntegrationTest do
     default_options = [name: name, sdk_key: sdk_key]
 
     with {:ok, _pid} <-
-           start_supervised({ConfigCat, Keyword.merge(default_options, options)}) do
+           start_supervised({ConfigCat, Keyword.merge(default_options, options)}, id: name) do
       {:ok, name}
     end
   end

--- a/test/using_block_test.exs
+++ b/test/using_block_test.exs
@@ -1,5 +1,8 @@
 defmodule ConfigCat.UsingBlockTest do
-  use ExUnit.Case, async: true
+  # Must be async: false to avoid a collision with the integration tests.
+  # Now that we only allow a single ConfigCat instance to use the same SDK key,
+  # one of the async tests would fail due to the existing running instance.
+  use ExUnit.Case, async: false
 
   defmodule CustomModule do
     @moduledoc false


### PR DESCRIPTION
**NOTE:** This PR is built on top of #107 and the base branch has been set accordingly. I'll rebase on main before merging.

### Describe the purpose of your pull request

- Switch the Supervisor to use a via_tuple with an extra "value" argument of the SDK key.
- When starting a new Supervisor, first check that there are no other supervisors already using that SDK key. If there are, raise an error.

The other SDKs return the matching instance after logging, but that's not really possible to do in an Elixir supervision tree, so instead we fail hard.

I've made some changes to the log message to match that reality, so it doesn't quite conform to the standardized log messages.

### Related issues (only if applicable)

https://trello.com/c/JpGvsIug/13-singleton-template-elixir

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
