### PR TITLE
Prepare 3.0.0 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,5 +40,5 @@ mix deps.get
 ## Running tests
 
 ```bash
-mix test
+mix coveralls.json
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,5 +40,5 @@ mix deps.get
 ## Running tests
 
 ```bash
-mix coveralls.json
+mix test
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ConfigCat is a [hosted feature flag service](http://configcat.com). Manage featu
 ```elixir
 def deps do
   [
-    {:configcat, "~> 2.0.0"}
+    {:configcat, "~> 3.0.0"}
   ]
 end
 ```

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -54,9 +54,9 @@ defmodule ConfigCat.Hooks do
   end
 
   @typedoc """
-  A module/function name/extra arguments tuple representing a callback function.
+  A hook callback is either an anonymous function or a module/function name/extra_arguments tuple.
 
-  Each callback passes specific arguments. These specific arguments are
+  Each callback is passed specific arguments. These specific arguments are
   prepended to the extra arguments provided in the tuple (if any).
 
   For example, you might want to define a callback that sends a message to

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ConfigCat.MixProject do
       name: "ConfigCat",
       source_url: @source_url,
       homepage_url: "https://configcat.com/",
-      version: "2.0.1",
+      version: "3.0.0",
       elixir: "~> 1.10",
       description: description(),
       package: package(),


### PR DESCRIPTION
## 3.0.0

### Breaking Changes
- Timeouts: `connect_timeout` and `read_timeout` options renamed to `connect_timeout_milliseconds` and `read_timeout_milliseconds` to indicate the unit of measure ([#80](https://github.com/configcat/elixir-sdk/pull/80))
- Cache: The `ConfigCache` behaviour has been changed to store and retrieve `String.t()` cache entries (was previously a `map()`). This matches the new generalized cache implementation that is consistent for all ConfigCat SDKs. In addition, the format of the cache keys has been changed to be consistent with the other platforms. With these changes, you can now implement your own `ConfigCache` implementation in persistent storage (e.g. Redis) and share the cache amongst multiple language implementations. ([#89](https://github.com/configcat/elixir-sdk/pull/81))
- Removed `get_variation_id`/`get_all_variation_ids`: These functions have been removed in favor of the new `get_value_details`/`get_all_value_details` functions (see below). ([#97](https://github.com/configcat/elixir-sdk/pull/97))
- Remove `on_changed` callback: Auto mode's `on_changed` callback has been removed. Use the new Hooks feature instead (see below). ([#99](https://github.com/configcat/elixir-sdk/pull/99))
- One instance per SDK key: When using multiple ConfigCat instances, each instance must be configured with a different SDK key. You must access all of your flags and settings through a single ConfigCat instance. ([#108](https://github.com/configcat/elixir-sdk/pull/108))
- Lazy cache policy: `cache_expiry_seconds` option has been renamed to `cache_refresh_interval_seconds`. ([#110](https://github.com/configcat/elixir-sdk/pull/110))

### Added
- Default User: You can now possible to specify a default user to use when no user is passed to the various `get_*` functions. You can pass the `default_user` option when starting ConfigCat or you can use `ConfigCat.set_default_user/1` and `ConfigCat.clear_default_user/0` to change the default user at any time. By default, there is no default user. ([#80](https://github.com/configcat/elixir-sdk/pull/80))
- Online/Offline mode: You can now take ConfigCat offline to keep it from making HTTP calls to the ConfigCat server. When offline, ConfigCat will operate using its most recent cached config. You can pass the `offline`  option when starting ConfigCat or you can use `ConfigCat.set_offline/0` and `ConfigCat.set_online/0` to toggle between online and offline mode. You can query the current state with `ConfigCat.offline?/0`. By default, ConfigCat is online. ([#81](https://github.com/configcat/elixir-sdk/pull/81))
- get_value_details/get_all_value_details: Adds new `get_value_details` and `get_all_value_details` functions that return `EvaluationDetails` structs containing information about flag evaluations, including the key and value, whether or not the default value was returned, the user, the variation, and any matched rules. See [the documentation](https://configcat.com/docs/sdk-reference/elixir/#anatomy-of-get_value_details) for more details. ([#96](https://github.com/configcat/elixir-sdk/pull/96), [#97](https://github.com/configcat/elixir-sdk/pull/97))
- Hooks: The new Hooks feature allows you to supply callback functions that are called by ConfigCat when significant events occur. See [the documentation](https://configcat.com/docs/sdk-reference/elixir/#hooks) for more information. ([#99](https://github.com/configcat/elixir-sdk/pull/99))
- Logger metadata: All log messages include two additional pieces of information (when available) both in the log messages and as [Logger metadata](https://hexdocs.pm/logger/1.15.5/Logger.html#module-metadata). The `instance_id` property matches the `name` property you specify when configuring multiple ConfigCat instances (defaults to `Elixir.ConfigCat`). The `event_id` property is a numeric error code that is common to all of the ConfigCat language SDKs. If you want to use the metadata properties, you'll need to [configure your Logger backend](https://hexdocs.pm/logger/1.15.5/Logger.html#module-boot-configuration) to include them. ([#100](https://github.com/configcat/elixir-sdk/pull/100))
- `max_init_wait_time_seconds` option: Auto mode now has a `max_init_wait_time_seconds` option. When ConfigCat first starts up, any calls to the `get_*` functions will wait for this many seconds for the initial config fetch to occur. If the fetch does not complete in time, the existing cached config (if any) will be used. Otherwise, the call will return the default value. Default: 5 seconds. ([#102](https://github.com/configcat/elixir-sdk/pull/102))
- Module-based multiple instances: If you need to run multiple instances of ConfigCat, you can now use new module-based approach. See [the documentation]((https://hexdocs.pm/configcat/ConfigCat.html#module-multiple-instances)) for more information. ([#104](https://github.com/configcat/elixir-sdk/pull/104))

### Changed
- Use latest fetch time and ETag: The new generalized cache format (see above) now includes the time at which the config was last fetched as well as the cache-control ETag. ConfigCat now uses that fetch time when determining whether or not to fetch in Lazy mode and when to start polling in Auto mode and uses the last-received ETag when fetching. When using the default `ConfigCache` implementation, this behavior is the same as it always was. But if you're using a persistent `ConfigCache` implementation, this means that ConfigCat can avoid re-fetching a new config when it starts up if the existing cached config is new enough and on the first fetch, the server can send back a 304 response if appropriate. ([#90](https://github.com/configcat/elixir-sdk/pull/90), [#94](https://github.com/configcat/elixir-sdk/pull/94))
- `force_refresh` return value: `ConfigCat.force_refresh/0` now returns `{:error, String.t()}` when it fails rather than leaking errors from HTTPoison. The typespec for that function has been tightened up accordingly. ([#101](https://github.com/configcat/elixir-sdk/pull/101))
- Reduced server round-trips: When multiple processes attempt to fetch the config while a fetch is already in progress, all of the requests will be satisfied by the result of the in-progress fetch. Previously, each request would be serialized and result in a new request to the server. ([#103](https://github.com/configcat/elixir-sdk/pull/103))
- Consistent log messages: Log messages are now consistent with the other SDKs, including the new `event_id` codes described above. ([#105](https://github.com/configcat/elixir-sdk/pull/105))
- Consolidated evaluation log: When evaluating a flag, a number of debug-level messages are logged. These messages are now collected together into a single log entry. ([#107](https://github.com/configcat/elixir-sdk/pull/107))

### Removed

### Fixed
- Last fetch time: When the server returns a 304 error, the last fetch time is now updated so that the next fetch request is delayed until the appropriate time. ([#101](https://github.com/configcat/elixir-sdk/pull/101))
- Errors in `local_only` mode: When using the `:local_only` [flag overrides](https://configcat.com/docs/sdk-reference/elixir/#flag-overrides) setting, some of the ConfigCat calls would fail with confusing error message. These calls are now handled cleanly, returning an appropriate result. ([#105](https://github.com/configcat/elixir-sdk/pull/105))



### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
