### PR TITLE
✅ Run more tests synchronously

### DIFF
--- a/samples/multi/lib/multi.ex
+++ b/samples/multi/lib/multi.ex
@@ -19,12 +19,12 @@ defmodule Multi do
 
   defmodule First do
     @moduledoc false
-    use ConfigCat, sdk_key: "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"
+    use ConfigCat, sdk_key: "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ"
   end
 
   defmodule Second do
     @moduledoc false
-    use ConfigCat, sdk_key: "PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ"
+    use ConfigCat, sdk_key: "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/tiOvFw5gkky9LFu1Duuvzw"
   end
 
   def start_link(_options) do

--- a/samples/simple/lib/simple/application.ex
+++ b/samples/simple/lib/simple/application.ex
@@ -5,7 +5,7 @@ defmodule Simple.Application do
 
   require Logger
 
-  @sdk_key "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A"
+  @sdk_key "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ"
 
   @impl Application
   def start(_type, _args) do

--- a/test/flag_override_test.exs
+++ b/test/flag_override_test.exs
@@ -1,5 +1,8 @@
 defmodule ConfigCat.FlagOverrideTest do
-  use ConfigCat.ClientCase, async: true
+  # Must be async: false to avoid a collision with other tests.
+  # Now that we only allow a single ConfigCat instance to use the same SDK key,
+  # one of the async tests would fail due to the existing running instance.
+  use ConfigCat.ClientCase, async: false
 
   import Jason.Sigil
 

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -9,7 +9,7 @@ defmodule ConfigCat.IntegrationTest do
   alias ConfigCat.InMemoryCache
   alias ConfigCat.LocalMapDataSource
 
-  @sdk_key "PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA"
+  @sdk_key "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/1cGEJXUwYUGZCBOL-E2sOw"
 
   describe "SDK key validation" do
     test "raises error if SDK key is missing" do

--- a/test/rollout_test.exs
+++ b/test/rollout_test.exs
@@ -1,5 +1,8 @@
 defmodule ConfigCat.RolloutTest do
-  use ConfigCat.Case, async: true
+  # Must be async: false to avoid a collision with other tests.
+  # Now that we only allow a single ConfigCat instance to use the same SDK key,
+  # one of the async tests would fail due to the existing running instance.
+  use ConfigCat.Case, async: false
 
   import ExUnit.CaptureLog
   import Jason.Sigil

--- a/test/using_block_test.exs
+++ b/test/using_block_test.exs
@@ -6,7 +6,7 @@ defmodule ConfigCat.UsingBlockTest do
 
   defmodule CustomModule do
     @moduledoc false
-    use ConfigCat, sdk_key: "PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA"
+    use ConfigCat, sdk_key: "configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/1cGEJXUwYUGZCBOL-E2sOw"
   end
 
   test "can call API through using block" do


### PR DESCRIPTION
**NOTE:** This PR is based on #131  and the base branch has been set accordingly. I'll rebase before merging.

### Describe the purpose of your pull request

More test files are using the same SDK keys which results in test failures when two tests with the same key try to start their own ConfigCat instances. Since we only allow a single instance per SDK key, this fails.

### Related issues (only if applicable)

[Provide links to issues relating to this pull request](https://trello.com/c/wpNt5Lqu/23-catnip)

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
