### PR TITLE
ConfigFetcher accepts ETag in a case-insensitive manner

### DIFF
--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -330,9 +330,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp extract_etag(headers) do
-    headers
-    |> Enum.find(fn {key, _value} -> String.downcase(key) == "etag" end)
-    |> case do
+    case Enum.find(headers, fn {key, _value} -> String.downcase(key) == "etag" end) do
       nil -> nil
       {_key, value} -> value
     end

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -330,7 +330,9 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp extract_etag(headers) do
-    case List.keyfind(headers, "ETag", 0) do
+    headers
+    |> Enum.find(fn {key, _value} -> String.downcase(key) == "etag" end)
+    |> case do
       nil -> nil
       {_key, value} -> value
     end

--- a/test/config_cat/config_fetcher_test.exs
+++ b/test/config_cat/config_fetcher_test.exs
@@ -138,6 +138,18 @@ defmodule ConfigCat.ConfigFetcherTest do
     assert {:ok, :unchanged} = ConfigFetcher.fetch(fetcher, @etag)
   end
 
+  test "returns unchanged response (with lowercase 'etag') when server responds that the config hasn't changed" do
+    {:ok, fetcher} = start_fetcher(@fetcher_options)
+
+    response = %Response{
+      status_code: 304,
+      headers: [{"etag", @etag}]
+    }
+
+    stub(MockAPI, :get, fn _url, _headers, _options -> {:ok, response} end)
+    assert {:ok, :unchanged} = ConfigFetcher.fetch(fetcher, @etag)
+  end
+
   @tag capture_log: true
   test "returns error for non-200 response from ConfigCat" do
     {:ok, fetcher} = start_fetcher(@fetcher_options)


### PR DESCRIPTION
### Describe the purpose of your pull request

ConfigFetcher accepts ETag in a case-insensitive manner.

### Related issues (only if applicable)

https://trello.com/c/RJ6Vbi8S/390-etag-header-%C3%A1tn%C3%A9z%C3%A9se

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
