### PR TITLE
Prepare 4.0.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ConfigCat is a [hosted feature flag service](http://configcat.com). Manage featu
 ```elixir
 def deps do
   [
-    {:configcat, "~> 4.0.0"}
+    {:configcat, "~> 4.0.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule ConfigCat.MixProject do
       name: "ConfigCat",
       source_url: @source_url,
       homepage_url: "https://configcat.com/",
-      version: "4.0.0",
+      version: "4.0.1",
       elixir: "~> 1.12",
       description: description(),
       package: package(),


### PR DESCRIPTION
## 4.0.1

ConfigFetcher accepts ETag in a case-insensitive manner to handle http/2 lowercase header keys.
