### PR TITLE
💚 Use a unique registry for every test

### DIFF
--- a/lib/config_cat/cache.ex
+++ b/lib/config_cat/cache.ex
@@ -46,7 +46,7 @@ defmodule ConfigCat.Cache do
   end
 
   defp via_tuple(instance_id) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}}}
+    ConfigCat.Registry.via_tuple(__MODULE__, instance_id)
   end
 
   @spec generate_key(String.t()) :: String.t()

--- a/lib/config_cat/cache_policy.ex
+++ b/lib/config_cat/cache_policy.ex
@@ -178,6 +178,6 @@ defmodule ConfigCat.CachePolicy do
   @doc false
   @spec via_tuple(ConfigCat.instance_id()) :: {:via, module(), term()}
   def via_tuple(instance_id) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}}}
+    ConfigCat.Registry.via_tuple(__MODULE__, instance_id)
   end
 end

--- a/lib/config_cat/client.ex
+++ b/lib/config_cat/client.ex
@@ -60,7 +60,7 @@ defmodule ConfigCat.Client do
 
   @spec via_tuple(ConfigCat.instance_id()) :: {:via, module(), term()}
   def via_tuple(instance_id) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}}}
+    ConfigCat.Registry.via_tuple(__MODULE__, instance_id)
   end
 
   @impl GenServer

--- a/lib/config_cat/config_fetcher.ex
+++ b/lib/config_cat/config_fetcher.ex
@@ -119,7 +119,7 @@ defmodule ConfigCat.CacheControlConfigFetcher do
   end
 
   defp via_tuple(instance_id) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}}}
+    ConfigCat.Registry.via_tuple(__MODULE__, instance_id)
   end
 
   @impl ConfigFetcher

--- a/lib/config_cat/hooks.ex
+++ b/lib/config_cat/hooks.ex
@@ -184,7 +184,7 @@ defmodule ConfigCat.Hooks do
   end
 
   defp via_tuple(instance_id) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}}}
+    ConfigCat.Registry.via_tuple(__MODULE__, instance_id)
   end
 
   @impl GenServer

--- a/lib/config_cat/registry.ex
+++ b/lib/config_cat/registry.ex
@@ -1,0 +1,13 @@
+defmodule ConfigCat.Registry do
+  @moduledoc false
+
+  @spec via_tuple(module(), ConfigCat.instance_id()) :: {:via, module(), term()}
+  def via_tuple(module, instance_id) do
+    {:via, Registry, {__MODULE__, {module, instance_id}}}
+  end
+
+  @spec via_tuple(module(), ConfigCat.instance_id(), term()) :: {:via, module(), term()}
+  def via_tuple(module, instance_id, value) do
+    {:via, Registry, {__MODULE__, {module, instance_id}, value}}
+  end
+end

--- a/lib/config_cat/registry.ex
+++ b/lib/config_cat/registry.ex
@@ -3,11 +3,16 @@ defmodule ConfigCat.Registry do
 
   @spec via_tuple(module(), ConfigCat.instance_id()) :: {:via, module(), term()}
   def via_tuple(module, instance_id) do
-    {:via, Registry, {__MODULE__, {module, instance_id}}}
+    {:via, Registry, {instance(), {module, instance_id}}}
   end
 
   @spec via_tuple(module(), ConfigCat.instance_id(), term()) :: {:via, module(), term()}
   def via_tuple(module, instance_id, value) do
-    {:via, Registry, {__MODULE__, {module, instance_id}, value}}
+    {:via, Registry, {instance(), {module, instance_id}, value}}
+  end
+
+  @spec instance :: module()
+  def instance do
+    ProcessTree.get(:registry, default: __MODULE__)
   end
 end

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -95,7 +95,7 @@ defmodule ConfigCat.Supervisor do
   end
 
   defp via_tuple(instance_id, sdk_key) do
-    {:via, Registry, {ConfigCat.Registry, {__MODULE__, instance_id}, sdk_key}}
+    ConfigCat.Registry.via_tuple(__MODULE__, instance_id, sdk_key)
   end
 
   @impl Supervisor

--- a/lib/config_cat/supervisor.ex
+++ b/lib/config_cat/supervisor.ex
@@ -62,7 +62,7 @@ defmodule ConfigCat.Supervisor do
   end
 
   defp ensure_unique_sdk_key(sdk_key) do
-    ConfigCat.Registry
+    ConfigCat.Registry.instance()
     |> Registry.select([{{{__MODULE__, :"$1"}, :_, sdk_key}, [], [:"$1"]}])
     |> case do
       [] ->

--- a/mix.exs
+++ b/mix.exs
@@ -81,6 +81,7 @@ defmodule ConfigCat.MixProject do
       {:jason, "~> 1.2"},
       {:mix_test_interactive, "~> 1.2", only: :dev, runtime: false},
       {:mox, "~> 1.1", only: :test},
+      {:process_tree, "~> 0.1.3"},
       {:styler, "~> 0.11", only: [:dev, :test], runtime: false},
       {:typed_struct, "~> 0.3.0"},
       {:tz, "~> 0.26.5", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -22,6 +22,7 @@
   "mox": {:hex, :mox, "1.1.0", "0f5e399649ce9ab7602f72e718305c0f9cdc351190f72844599545e4996af73c", [:mix], [], "hexpm", "d44474c50be02d5b72131070281a5d3895c0e7a95c780e90bc0cfe712f633a13"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "parse_trans": {:hex, :parse_trans, "3.4.1", "6e6aa8167cb44cc8f39441d05193be6e6f4e7c2946cb2759f015f8c56b76e5ff", [:rebar3], [], "hexpm", "620a406ce75dada827b82e453c19cf06776be266f5a67cff34e1ef2cbb60e49a"},
+  "process_tree": {:hex, :process_tree, "0.1.3", "12ca2724d74b211bcb106659cb64d11a88fe6e8e3256071c601233d469235665", [:mix], [], "hexpm", "156e8b4f8ed51f80dd134fc0de89af1ad3ec84a255a9c036c92a2e02e3b24302"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "styler": {:hex, :styler, "0.11.9", "2595393b94e660cd6e8b582876337cc50ff047d184ccbed42fdad2bfd5d78af5", [:mix], [], "hexpm", "8b7806ba1fdc94d0a75127c56875f91db89b75117fcc67572661010c13e1f259"},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},

--- a/test/config_cat_test.exs
+++ b/test/config_cat_test.exs
@@ -1,5 +1,8 @@
 defmodule ConfigCatTest do
-  use ConfigCat.ClientCase, async: true
+  # Must be async: false to avoid a collision with other tests.
+  # Now that we only allow a single ConfigCat instance to use the same SDK key,
+  # one of the async tests would fail due to the existing running instance.
+  use ConfigCat.ClientCase, async: false
 
   import ExUnit.CaptureLog
   import Jason.Sigil

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -68,10 +68,11 @@ defmodule ConfigCat.IntegrationTest do
 
     @tag capture_log: true
     test "raises error when starting another instance with the same SDK key" do
-      {:ok, _} = start(@sdk_key, name: :original)
+      registry = start_registry()
+      {:ok, _} = start(@sdk_key, name: :original, registry: registry)
 
       assert {:error, {{:EXIT, {error, _stacktrace}}, _spec}} =
-               start(@sdk_key, name: :duplicate)
+               start(@sdk_key, name: :duplicate, registry: registry)
 
       assert %ArgumentError{message: message} = error
       assert message =~ ~r/existing ConfigCat instance/

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -28,6 +28,7 @@ defmodule ConfigCat.Case do
 
   @spec start_config_cat(String.t(), keyword) :: {:ok, GenServer.name()}
   def start_config_cat(sdk_key, options \\ []) do
+    {registry, options} = Keyword.pop_lazy(options, :registry, &start_registry/0)
     name = String.to_atom(UUID.uuid4())
 
     default_options = [
@@ -36,8 +37,18 @@ defmodule ConfigCat.Case do
       sdk_key: sdk_key
     ]
 
+    Process.put(:registry, registry)
+
     with {:ok, _pid} <- start_supervised({ConfigCat, Keyword.merge(default_options, options)}, id: name) do
       {:ok, name}
     end
+  end
+
+  @spec start_registry :: GenServer.name()
+  def start_registry do
+    name = String.to_atom(UUID.uuid4())
+    _pid = start_supervised!({Registry, keys: :unique, name: name})
+
+    name
   end
 end

--- a/test/support/client_case.ex
+++ b/test/support/client_case.ex
@@ -4,6 +4,7 @@ defmodule ConfigCat.ClientCase do
   use ExUnit.CaseTemplate
 
   alias ConfigCat.Client
+  alias ConfigCat.Config
   alias ConfigCat.FetchTime
   alias ConfigCat.Hooks
   alias ConfigCat.MockCachePolicy


### PR DESCRIPTION
### Describe the purpose of your pull request

In order to fix the frequently-failing tests, this takes a different approach in addition to running many of the tests synchronously.

It seems as though our ConfigCat instances aren't fully shutting down and removing themselves from the Registry before the next test starts, even though they should be doing that.

Instead, we start a uniquely-named Registry for each test, injecting it into the code using the [ProcessTree](https://hexdocs.pm/process_tree/ProcessTree.html) library.

We allow tests to start their own Registry and pass it into the `start_config_cat` helper function for the one that needs to refer to the exact same registry.

To make this cleaner, we extract a `via_tuple` helper function into a new `ConfigCat.Registry` module so that we can localize the lookup of the registry to use.

This is an alternative to #142.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
